### PR TITLE
Timeseries factory refactor

### DIFF
--- a/geomagio/StreamTimeseriesFactory.py
+++ b/geomagio/StreamTimeseriesFactory.py
@@ -1,0 +1,43 @@
+"""Stream wrapper for TimeseriesFactory."""
+
+from TimeseriesFactory import TimeseriesFactory
+
+
+class StreamTimeseriesFactory(TimeseriesFactory):
+    """Timeseries Factory for streams.
+        normally stdio.
+
+    Parameters
+    ----------
+    factory: geomagio.TimeseriesFactory
+        wrapped factory.
+    stream: file object
+        io stream, normally either a file, or stdio
+
+    See Also
+    --------
+    Timeseriesfactory
+    """
+    def __init__(self, factory, stream):
+        self.factory = factory
+        self.stream = stream
+        self.stream_data = None
+
+    def get_timeseries(self, starttime, endtime, observatory=None,
+            channels=None, type=None, interval=None):
+        """Get timeseries using stream as input.
+        """
+        if self.stream_data is None:
+            # only read stream once
+            self.stream_data = self.stream.read()
+        return self.factory.parse_string(
+                data=self.stream_data,
+                starttime=starttime,
+                endtime=endtime,
+                observatory=observatory)
+
+    def put_timeseries(self, timeseries, starttime=None, endtime=None,
+            channels=None, type=None, interval=None):
+        """Put timeseries using stream as output.
+        """
+        self.factory.write_file(self.stream, timeseries, channels)

--- a/geomagio/Util.py
+++ b/geomagio/Util.py
@@ -143,7 +143,7 @@ def read_url(url, connect_timeout=15, max_redirects=5, timeout=300):
 
     Raises
     ------
-    urllib2.URLError
+    IOError
         if any occurs
     """
     try:
@@ -167,6 +167,8 @@ def read_url(url, connect_timeout=15, max_redirects=5, timeout=300):
         curl.setopt(pycurl.WRITEFUNCTION, out.write)
         curl.perform()
         content = out.getvalue()
+    except pycurl.error as e:
+        raise IOError(e.args)
     finally:
         curl.close()
     return content

--- a/geomagio/edge/EdgeFactory.py
+++ b/geomagio/edge/EdgeFactory.py
@@ -15,7 +15,7 @@ import numpy
 import numpy.ma
 import obspy.core
 from datetime import datetime
-from obspy import earthworm
+from obspy.clients import earthworm
 from obspy.core import UTCDateTime
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactory import TimeseriesFactory
@@ -530,7 +530,7 @@ class EdgeFactory(TimeseriesFactory):
                 type, interval)
         edge_channel = self._get_edge_channel(observatory, channel,
                 type, interval)
-        data = self.client.getWaveform(network, station, location,
+        data = self.client.get_waveforms(network, station, location,
                 edge_channel, starttime, endtime)
         data.merge()
         if data.count() == 0:
@@ -575,7 +575,7 @@ class EdgeFactory(TimeseriesFactory):
         Parameters
         ----------
         timeseries: obspy.core.stream
-            The timeseries stream as returned by the call to getWaveform
+            The timeseries stream as returned by the call to get_waveforms
         starttime: obspy.core.UTCDateTime
             the starttime of the requested data
         endtime: obspy.core.UTCDateTime

--- a/geomagio/edge/EdgeFactory.py
+++ b/geomagio/edge/EdgeFactory.py
@@ -15,8 +15,12 @@ import numpy
 import numpy.ma
 import obspy.core
 from datetime import datetime
-from obspy.clients import earthworm
-from obspy.core import UTCDateTime
+try:
+    # obspy 1.x
+    from obspy.clients import earthworm
+except:
+    # obspy 0.x
+    from obspy import earthworm
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactory import TimeseriesFactory
 from ..TimeseriesFactoryException import TimeseriesFactoryException
@@ -209,8 +213,8 @@ class EdgeFactory(TimeseriesFactory):
         Notes: the original timeseries object is changed.
         """
         for trace in timeseries:
-            trace_starttime = UTCDateTime(trace.stats.starttime)
-            trace_endtime = UTCDateTime(trace.stats.endtime)
+            trace_starttime = obspy.core.UTCDateTime(trace.stats.starttime)
+            trace_endtime = obspy.core.UTCDateTime(trace.stats.endtime)
 
             if trace.stats.starttime > starttime:
                 cnt = int((trace_starttime - starttime) / trace.stats.delta)
@@ -553,11 +557,11 @@ class EdgeFactory(TimeseriesFactory):
         Returns
         -------
         tuple: (starttime, endtime)
-            starttime: UTCDateTime
-            endtime: UTCDateTime
+            starttime: obspy.core.UTCDateTime
+            endtime: obspy.core.UTCDateTime
         """
-        starttime = UTCDateTime(datetime.now())
-        endtime = UTCDateTime(0)
+        starttime = obspy.core.UTCDateTime(datetime.now())
+        endtime = obspy.core.UTCDateTime(0)
         for trace in timeseries:
             if trace.stats.starttime < starttime:
                 starttime = trace.stats.starttime
@@ -614,8 +618,8 @@ class EdgeFactory(TimeseriesFactory):
             data type.
         interval: {'daily', 'hourly', 'minute', 'second'}
             data interval.
-        starttime: UTCDateTime
-        endtime: UTCDateTime
+        starttime: obspy.core.UTCDateTime
+        endtime: obspy.core.UTCDateTime
 
         Notes
         -----
@@ -630,7 +634,7 @@ class EdgeFactory(TimeseriesFactory):
         edge_channel = self._get_edge_channel(observatory, channel,
                 type, interval)
 
-        now = UTCDateTime(datetime.utcnow())
+        now = obspy.core.UTCDateTime(datetime.utcnow())
         if ((now - endtime) > 864000) and (self.cwbport > 0):
             host = self.cwbhost
             port = self.cwbport

--- a/geomagio/imfv122/IMFV122Parser.py
+++ b/geomagio/imfv122/IMFV122Parser.py
@@ -100,7 +100,7 @@ class IMFV122Parser(object):
             dayminute = int(start)
             hour = int(dayminute / 60)
             minute = dayminute % 60
-            self._delta = 1
+            self._delta = 60
         self._nexttime = UTCDateTime(
                 year=year,
                 julday=julday,

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     packages=[
         'geomagio',
         'geomagio.algorithm',
+        'geomagio.binlog',
         'geomagio.edge',
         'geomagio.iaga2002',
         'geomagio.imfv122',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='geomag-algorithms',
-    version='0.0.0',
+    version='0.2.0',
     description='USGS Geomag IO Library',
     url='https://github.com/usgs/geomag-algorithms',
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,13 @@ setup(
     packages=[
         'geomagio',
         'geomagio.algorithm',
-        'geomagio.iaga2002',
-        'geomagio.imfv283',
         'geomagio.edge',
-        'geomagio.pcdcp'
+        'geomagio.iaga2002',
+        'geomagio.imfv122',
+        'geomagio.imfv283',
+        'geomagio.pcdcp',
+        'geomagio.temperature',
+        'geomagio.vbf'
     ],
     install_requires=[
         'numpy',

--- a/test/imfv122_test/IMFV122Parser_test.py
+++ b/test/imfv122_test/IMFV122Parser_test.py
@@ -5,7 +5,7 @@ from geomagio.imfv122 import IMFV122Parser
 from obspy.core import UTCDateTime
 
 
-def test_imfv122_parse_header__minutes():
+def test_imfv122_parse_header__hour_of_day():
     """imfv122_test.test_imfv122_parse_header__minutes.
     """
     parser = IMFV122Parser()
@@ -21,7 +21,7 @@ def test_imfv122_parse_header__minutes():
     assert_equals(parser._nexttime, UTCDateTime('2016-05-02T03:00:00Z'))
 
 
-def test_imfv122_parse_header__seconds():
+def test_imfv122_parse_header__minute_of_day():
     """imfv122_test.test_imfv122_parse_header__seconds.
     """
     parser = IMFV122Parser()
@@ -33,7 +33,7 @@ def test_imfv122_parse_header__seconds():
     assert_equals(metadata['geodetic_latitude'], 124.4)
     assert_equals(metadata['geodetic_longitude'], 19.2)
     assert_equals(metadata['station'], 'HER')
-    assert_equals(parser._delta, 1)
+    assert_equals(parser._delta, 60)
     assert_equals(parser._nexttime, UTCDateTime('2016-01-01T02:03:00Z'))
 
 
@@ -44,12 +44,14 @@ def test_imfv122_parse_data():
     parser._parse_header(
             'HER JAN0116 001 0123 HDZF R EDI 12440192 -14161 DRRRRRRRRRRRRRRR')
     parser._parse_data('1234 5678 9101 1121 3141 5161 7181 9202')
+    import pprint
+    pprint.pprint(parser._parsedata)
     assert_equals(parser._parsedata[0][0], UTCDateTime('2016-01-01T02:03:00Z'))
     assert_equals(parser._parsedata[1][0], '1234')
     assert_equals(parser._parsedata[2][0], '5678')
     assert_equals(parser._parsedata[3][0], '9101')
     assert_equals(parser._parsedata[4][0], '1121')
-    assert_equals(parser._parsedata[0][1], UTCDateTime('2016-01-01T02:03:01Z'))
+    assert_equals(parser._parsedata[0][1], UTCDateTime('2016-01-01T02:04:00Z'))
     assert_equals(parser._parsedata[1][1], '3141')
     assert_equals(parser._parsedata[2][1], '5161')
     assert_equals(parser._parsedata[3][1], '7181')
@@ -69,7 +71,7 @@ def test_imfv122_post_process():
     assert_equals(parser.data['D'][0], 56.78)
     assert_equals(parser.data['Z'][0], 910.1)
     assert_equals(parser.data['F'][0], 112.1)
-    assert_equals(parser.times[1], UTCDateTime('2016-01-01T02:03:01Z'))
+    assert_equals(parser.times[1], UTCDateTime('2016-01-01T02:04:00Z'))
     assert_equals(parser.data['H'][1], 314.1)
     assert_equals(parser.data['D'][1], 51.61)
     assert_equals(parser.data['Z'][1], 718.1)


### PR DESCRIPTION
- Fix imfv122 parsing for "minute of day" headers
- Separate url/stdio stream factory logic into shared class
- Update TimeseriesFactory base class to trim/pad returned timeseries for better gap detection
- Update edge factory for obspy 1.x api
- Add missing packages to setup.py
- Update setup.py version to 0.2.0 (for 0.2.0 release based on this pr)
