### PR TITLE
SqDist local smoothing

### DIFF
--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -471,7 +471,7 @@ class SqDistAlgorithm(Algorithm):
                 s[i + 1:i + nts / 2 + 1] = (s[i + 1:i + nts / 2 + 1] +
                                             gamma * (1 - alpha) * et *
                                             weights[nts / 2 + 1:])
- 
+
                 # update l and b using equation-error formulation
                 l = l + phi * b + alpha * et
                 b = phi * b + alpha * beta * et

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -436,6 +436,14 @@ class SqDistAlgorithm(Algorithm):
                 # performance.
                 r[i + 1] = gamma * (1 - alpha) * et / m
 
+                ## this properly smooths SQ locally; figure out if we need an
+                ## input parameter to control this, or if we just fix it to a
+                ## reasonable, but static value; also, figure out how/if r
+                ## needs to be changed  -EJR 8/2016
+                #s[i + m] = s[i] + gamma * (1 - alpha) * et / 61.
+                #s[i+m-30:i+m] = s[i+m-30:i+m] + gamma * (1-alpha) * et / 61.
+                #s[i+1:i+30+1] = s[i+1:i+30+1] + gamma * (1-alpha) * et / 61.
+
                 # update and append to s using equation-error formulation
                 s[i + m] = s[i] + gamma * (1 - alpha) * et
 

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -376,11 +376,10 @@ class SqDistAlgorithm(Algorithm):
         sig = np.sqrt(-2 * np.log(fom) / omg**2) + np.finfo(float).eps  # sig>0
         ts = np.linspace(np.max((-m, -3 * np.round(sig))),
                          np.min((m, 3 * np.round(sig))),
-                         np.min((2 *m, 6 * np.round(sig))) + 1)
+                         np.min((2 * m, 6 * np.round(sig))) + 1)
         nts = ts.size
         weights = np.exp(-0.5 * (ts / sig)**2)
         weights = weights / np.sum(weights)
-
 
         #
         # Now begin the actual Holt-Winters algorithm
@@ -460,17 +459,17 @@ class SqDistAlgorithm(Algorithm):
                 # performance.
                 r[i + 1] = gamma * (1 - alpha) * et / m
 
-                # update and append to s using equation-error formulation
-                #s[i + m] = s[i] + gamma * (1 - alpha) * et
+                # #update and append to s using equation-error formulation
+                # s[i + m] = s[i] + gamma * (1 - alpha) * et
 
                 # distribute error correction across range of seasonal
                 # corrections according to weights calculated above 
                 s[i + m] = s[i] + gamma * (1 - alpha) * et * weights[nts / 2]
-                s[i + m - nts / 2:i + m] = (s[i + m - nts / 2:i + m] + 
-                                            gamma * (1 - alpha) * et * 
+                s[i + m - nts / 2:i + m] = (s[i + m - nts / 2:i + m] +
+                                            gamma * (1 - alpha) * et *
                                             weights[:nts / 2])
-                s[i + 1:i + nts / 2 + 1] = (s[i + 1:i + nts / 2 + 1] + 
-                                            gamma * (1 - alpha) * et * 
+                s[i + 1:i + nts / 2 + 1] = (s[i + 1:i + nts / 2 + 1] +
+                                            gamma * (1 - alpha) * et *
                                             weights[nts / 2 + 1:])
                 
                 # update l and b using equation-error formulation

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -230,12 +230,13 @@ class SqDistAlgorithm(Algorithm):
         out += self.create_trace(channel + '_Dist', trace.stats, dist)
         out += self.create_trace(channel + '_SQ', trace.stats, sq)
         out += self.create_trace(channel + '_SV', trace.stats, sv)
+        out += self.create_trace(channel + '_Sigma', trace.stats, sigmahat)
         return out
 
     @classmethod
     def additive(cls, yobs, m, alpha, beta, gamma, phi=1,
                  yhat0=None, s0=None, l0=None, b0=None, sigma0=None,
-                 zthresh=6, fc=0, hstep=0):
+                 zthresh=6, fc=0, hstep=0, smooth=1):
         """Primary function for Holt-Winters smoothing/forecasting with
           damped linear trend and additive seasonal component.
 
@@ -291,6 +292,9 @@ class SqDistAlgorithm(Algorithm):
         hstep : int
             the number of steps ahead to predict yhat[i]
             which forces an hstep prediction at each time step
+        smooth: int
+            period (in samples) at which Gaussian smoother will attenuate
+            signal power by half
 
         Returns
         -------
@@ -357,6 +361,27 @@ class SqDistAlgorithm(Algorithm):
             if len(sigma) != (hstep + 1):
                 raise AlgorithmException(
                     "sigma0 must have length %d" % (hstep + 1))
+
+
+        # generate a vector of weights that will "smooth" seasonal
+        # variations locally...the quotes are because what we really
+        # do is distribute the error correction across a range of
+        # seasonal corrections; we do NOT convovle this filter with
+        # a signal to dampen noise, as is typical. -EJR 10/2016
+        
+        # smooth parameter should specify the required cut-off period in terms
+        # of discrete samples; for now, we generate a Gaussian filter according
+        # to White et al. (USGS SIR 2014-5045).
+        fom = 10**(-3/20.) # halve power at corner frequency
+        omg = np.pi / np.float64(smooth) # corner angular frequency
+        sig = np.sqrt(-2*np.log(fom)/omg**2) + np.finfo(float).eps # prevent sig==0
+        ts = np.linspace(np.max((-m, -3*np.round(sig))),
+                         np.min((m, 3*np.round(sig))),
+                         np.min((2*m, 6*np.round(sig))) + 1) # this is alwyays symmetric
+        nts = ts.size
+        weights = np.exp(-0.5 * (ts / sig)**2)
+        weights = weights / np.sum(weights)
+
 
         #
         # Now begin the actual Holt-Winters algorithm
@@ -436,17 +461,15 @@ class SqDistAlgorithm(Algorithm):
                 # performance.
                 r[i + 1] = gamma * (1 - alpha) * et / m
 
-                ## this properly smooths SQ locally; figure out if we need an
-                ## input parameter to control this, or if we just fix it to a
-                ## reasonable, but static value; also, figure out how/if r
-                ## needs to be changed  -EJR 8/2016
-                #s[i + m] = s[i] + gamma * (1 - alpha) * et / 61.
-                #s[i+m-30:i+m] = s[i+m-30:i+m] + gamma * (1-alpha) * et / 61.
-                #s[i+1:i+30+1] = s[i+1:i+30+1] + gamma * (1-alpha) * et / 61.
+                ## update and append to s using equation-error formulation
+                #s[i + m] = s[i] + gamma * (1 - alpha) * et
 
-                # update and append to s using equation-error formulation
-                s[i + m] = s[i] + gamma * (1 - alpha) * et
-
+                # distribute error correction across range of seasonal
+                # corrections according to weights calculated above 
+                s[i + m] = s[i] + gamma * (1-alpha) * et * weights[nts/2]
+                s[i+m-nts/2:i+m] = s[i+m-nts/2:i+m] + gamma * (1-alpha) * et * weights[:nts/2]
+                s[i+1:i+nts/2+1] = s[i+1:i+nts/2+1] + gamma * (1-alpha) * et * weights[nts/2+1:]
+                
                 # update l and b using equation-error formulation
                 l = l + phi * b + alpha * et
                 b = phi * b + alpha * beta * et
@@ -617,6 +640,9 @@ class SqDistAlgorithm(Algorithm):
         parser.add_argument('--sqdist-zthresh',
                 default=6,
                 help='Set Z-score threshold')
+        parser.add_argument('--sqdist-smooth',
+                default=1,
+                help='Local SQ smoothing parameter')
 
     def configure(self, arguments):
         """Configure algorithm using comand line arguments.
@@ -634,4 +660,5 @@ class SqDistAlgorithm(Algorithm):
         self.mag = arguments.sqdist_mag
         self.statefile = arguments.sqdist_statefile
         self.zthresh = arguments.sqdist_zthresh
+        self.smooth = arguments.sqdist_smooth
         self.load_state()

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -362,22 +362,21 @@ class SqDistAlgorithm(Algorithm):
                 raise AlgorithmException(
                     "sigma0 must have length %d" % (hstep + 1))
 
-
         # generate a vector of weights that will "smooth" seasonal
         # variations locally...the quotes are because what we really
         # do is distribute the error correction across a range of
         # seasonal corrections; we do NOT convovle this filter with
         # a signal to dampen noise, as is typical. -EJR 10/2016
-        
+
         # smooth parameter should specify the required cut-off period in terms
         # of discrete samples; for now, we generate a Gaussian filter according
         # to White et al. (USGS SIR 2014-5045).
-        fom = 10**(-3/20.) # halve power at corner frequency
-        omg = np.pi / np.float64(smooth) # corner angular frequency
-        sig = np.sqrt(-2*np.log(fom)/omg**2) + np.finfo(float).eps # prevent sig==0
-        ts = np.linspace(np.max((-m, -3*np.round(sig))),
-                         np.min((m, 3*np.round(sig))),
-                         np.min((2*m, 6*np.round(sig))) + 1) # this is alwyays symmetric
+        fom = 10**(-3 / 20.)  # halve power at corner frequency
+        omg = np.pi / np.float64(smooth)  # corner angular frequency
+        sig = np.sqrt(-2 * np.log(fom) / omg**2) + np.finfo(float).eps  # sig>0
+        ts = np.linspace(np.max((-m, -3 * np.round(sig))),
+                         np.min((m, 3 * np.round(sig))),
+                         np.min((2 *m, 6 * np.round(sig))) + 1)
         nts = ts.size
         weights = np.exp(-0.5 * (ts / sig)**2)
         weights = weights / np.sum(weights)
@@ -461,14 +460,18 @@ class SqDistAlgorithm(Algorithm):
                 # performance.
                 r[i + 1] = gamma * (1 - alpha) * et / m
 
-                ## update and append to s using equation-error formulation
+                # update and append to s using equation-error formulation
                 #s[i + m] = s[i] + gamma * (1 - alpha) * et
 
                 # distribute error correction across range of seasonal
                 # corrections according to weights calculated above 
-                s[i + m] = s[i] + gamma * (1-alpha) * et * weights[nts/2]
-                s[i+m-nts/2:i+m] = s[i+m-nts/2:i+m] + gamma * (1-alpha) * et * weights[:nts/2]
-                s[i+1:i+nts/2+1] = s[i+1:i+nts/2+1] + gamma * (1-alpha) * et * weights[nts/2+1:]
+                s[i + m] = s[i] + gamma * (1 - alpha) * et * weights[nts / 2]
+                s[i + m - nts / 2:i + m] = (s[i + m - nts / 2:i + m] + 
+                                            gamma * (1 - alpha) * et * 
+                                            weights[:nts / 2])
+                s[i + 1:i + nts / 2 + 1] = (s[i + 1:i + nts / 2 + 1] + 
+                                            gamma * (1 - alpha) * et * 
+                                            weights[nts / 2 + 1:])
                 
                 # update l and b using equation-error formulation
                 l = l + phi * b + alpha * et

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -463,7 +463,7 @@ class SqDistAlgorithm(Algorithm):
                 # s[i + m] = s[i] + gamma * (1 - alpha) * et
 
                 # distribute error correction across range of seasonal
-                # corrections according to weights calculated above 
+                # corrections according to weights calculated above
                 s[i + m] = s[i] + gamma * (1 - alpha) * et * weights[nts / 2]
                 s[i + m - nts / 2:i + m] = (s[i + m - nts / 2:i + m] +
                                             gamma * (1 - alpha) * et *
@@ -471,7 +471,7 @@ class SqDistAlgorithm(Algorithm):
                 s[i + 1:i + nts / 2 + 1] = (s[i + 1:i + nts / 2 + 1] +
                                             gamma * (1 - alpha) * et *
                                             weights[nts / 2 + 1:])
-                
+ 
                 # update l and b using equation-error formulation
                 l = l + phi * b + alpha * et
                 b = phi * b + alpha * beta * et


### PR DESCRIPTION
I implemented local smoothing for SQ to address previously noted issues with both real and artificial high-frequency noise that could not be addressed efficiently via the standard exponential smoothing parameter gamma. This required some relatively small changes to SqDistAlgorithm.additive(), including a new configuration parameter. It also required related changes to the command-line options.

I don't believe this change is substantial enough to warrant a full and formal peer review. However, I tested things on 6-months of 2003 data (includes the so-called Halloween Storm) from 3 different observatories, and everything worked as expected. I'm attaching representative snapshots of the BOU results that demonstrate just what this new parameter does when a "cutoff period" of 3 hours (180 1-minute samples) is specified.

![bou_solarquiet009](https://cloud.githubusercontent.com/assets/11222895/19569688/f1318066-96b3-11e6-9c3c-334151feb262.png)

![bou_solarquiet009](https://cloud.githubusercontent.com/assets/11222895/19569707/00faa194-96b4-11e6-975b-71e7202e79be.png)


I discussed these positive results with both Abe Claycomb and Tim White.  We all agreed that the choice to use a Gaussian filter over a boxcar filter was appropriate. Tim, not unexpectedly, encouraged using a more sophisticated filter. I might do this in the future, but for now the Gaussian filter meets our somewhat loosely defined requirements in terms of spectral response. 