### PR TITLE
Pad to urlInterval in put_timeseries()

### DIFF
--- a/geomagio/TimeseriesFactory.py
+++ b/geomagio/TimeseriesFactory.py
@@ -226,6 +226,13 @@ class TimeseriesFactory(object):
                         trace.stats.location = new_trace.stats.location
                     url_data = TimeseriesUtility.merge_streams(
                             existing_data, url_data)
+                    # pad with NaN's out to urlInterval (like get_timeseries())
+                    url_data.trim(
+                          starttime=urlInterval['start'],
+                          endtime=(urlInterval['end'] - delta),
+                          nearest_sample=False,
+                          pad=True,
+                          fill_value=numpy.nan)
                 except IOError:
                     # no data yet
                     pass

--- a/geomagio/TimeseriesFactory.py
+++ b/geomagio/TimeseriesFactory.py
@@ -226,19 +226,19 @@ class TimeseriesFactory(object):
                         trace.stats.location = new_trace.stats.location
                     url_data = TimeseriesUtility.merge_streams(
                             existing_data, url_data)
-                    # pad with NaN's out to urlInterval (like get_timeseries())
-                    url_data.trim(
-                          starttime=urlInterval['start'],
-                          endtime=(urlInterval['end'] - delta),
-                          nearest_sample=False,
-                          pad=True,
-                          fill_value=numpy.nan)
                 except IOError:
                     # no data yet
                     pass
                 except NotImplementedError:
                     # factory only supports output
                     pass
+            # pad with NaN's out to urlInterval (like get_timeseries())
+            url_data.trim(
+                starttime=urlInterval['start'],
+                endtime=(urlInterval['end'] - delta),
+                nearest_sample=False,
+                pad=True,
+                fill_value=numpy.nan)
             with open(url_file, 'wb') as fh:
                 try:
                     self.write_file(fh, url_data, channels)


### PR DESCRIPTION
TimeseriesFactory.get_timeseries() pads to the requested interval with NaNs,
filling in start/end gaps. TimeseriesFactory.put_timeseries() is supposed to
do this (according to Jeremy Fee), but it was trimming NaNs from the start/
end before writing to file. This PR fixes this by using ObsPy's Stream.trim()
method, in a similar manner to TimesereisFactory.get_timeseries(), to pad to
the specified start and end of the urlInterval..