### PR TITLE
Better default l0 in additive() method, etc.

### DIFF
--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -328,6 +328,8 @@ class SqDistAlgorithm(Algorithm):
         # set some default values
         if l0 is None:
             l = np.nanmean(yobs[0:int(m)])
+            if l is np.nan:
+               l = 0.
         else:
             l = l0
             if not np.isscalar(l0):
@@ -487,7 +489,7 @@ class SqDistAlgorithm(Algorithm):
 
         r = np.cumsum(r)
         l = l + r[-1]
-        s = list(np.array(s) - np.hstack((r, np.tile(r[-1], m - 1))))
+        s = np.array(s) - np.hstack((r, np.tile(r[-1], m - 1)))
 
         return (yhat[:len(yobs) + fc],
                 s[:len(yobs) + fc],

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -329,7 +329,7 @@ class SqDistAlgorithm(Algorithm):
         if l0 is None:
             l = np.nanmean(yobs[0:int(m)])
             if l is np.nan:
-               l = 0.
+                l = 0.
         else:
             l = l0
             if not np.isscalar(l0):


### PR DESCRIPTION
Previously, if l0 was None, we tried to calculate a default initial level. This was
problematic if yobs had no valid points from which to calculate a mean. Now, if yobs
has no valid points, default to l0=0. This is a bit arbitrary, but it is necessary
to prevent a NaN-valued l from being passed back out. Other defaults are equally
arbitrary.

Also, I noticed that the `s` variable was getting converted from a NumPy array to a
list just before the method returned. For consistency with other outputs, we no
longer convert, and just return a NumPy array.