### PR TITLE
fix dead IAGA links in documentation 

### DIFF
--- a/docs/algorithms/Adjusted.md
+++ b/docs/algorithms/Adjusted.md
@@ -130,7 +130,7 @@ adjusting manually and previewing the effect on delta F,  etc.
 
 ## References
 
- - Jankowski, J., and Sucksdorff, C., [Guide for Magnetic Measurements and Observatory Practice](http://www.iugg.org/IAGA/iaga-pages/pdf/Iaga-Guide-Observatories.pdf),
+ - Jankowski, J., and Sucksdorff, C., [Guide for Magnetic Measurements and Observatory Practice](http://www.iaga-aiga.org/data/uploads/pdf/guides/iaga-guide-observatories.pdf),
    Int. J. of Forecasting, 19(1), 143-148.
 
  - Hitchman, P. G., Crosthwaite, W. V., Lewis, A. M., and Wang, L. (2011), [Australian Geomagnetism Report 2011](https://d28rz98at9flks.cloudfront.net/73627/Rec2012_072.pdf)

--- a/geomagio/iaga2002/IAGA2002Parser.py
+++ b/geomagio/iaga2002/IAGA2002Parser.py
@@ -16,7 +16,7 @@ class IAGA2002Parser(object):
     """IAGA2002 parser.
 
     Based on documentation at:
-      http://www.ngdc.noaa.gov/IAGA/vdat/iagaformat.html
+      https://www.ngdc.noaa.gov/IAGA/vdat/IAGA2002/iaga2002format.html
 
     Attributes
     ----------

--- a/geomagio/iaga2002/__init__.py
+++ b/geomagio/iaga2002/__init__.py
@@ -1,7 +1,7 @@
 """IO Module for IAGA 2002 Format
 
 Based on documentation at:
-  http://www.ngdc.noaa.gov/IAGA/vdat/iagaformat.html
+  https://www.ngdc.noaa.gov/IAGA/vdat/IAGA2002/iaga2002format.html
 """
 
 from IAGA2002Factory import IAGA2002Factory


### PR DESCRIPTION
Hello folks,

I noticed some of the links in the docs pointed to dead parts of the IAGA website.
I've forked and updated them.
Should close #147 .

Cheers,
Laurence