### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.6
+  - 3.5
 before_install:
   ## courtesy of http://conda.pydata.org/docs/travis.html
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: python
 python:
   - 2.7
+  - 3.6
 before_install:
   ## courtesy of http://conda.pydata.org/docs/travis.html
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 language: python
 python:
   - 2.7
+  - 3.3
+  - 3.4
   - 3.5
 before_install:
   ## courtesy of http://conda.pydata.org/docs/travis.html

--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -1,7 +1,8 @@
 """Module for bin
 """
+from __future__ import absolute_import
 
-import geomag
+from . import geomag
 
 __all__ = [
     'geomag'

--- a/bin/main.py
+++ b/bin/main.py
@@ -23,7 +23,7 @@ def main():
             interval='minute', type='variation')
     timeseries = factory.get_timeseries(
             UTCDateTime('2014-11-01'), UTCDateTime('2014-11-02'))
-    print timeseries
+    print(timeseries)
 
 
 if __name__ == '__main__':

--- a/bin/make_cal.py
+++ b/bin/make_cal.py
@@ -4,7 +4,7 @@
 Usage:
     python make_cal.py OBSERVATORY YEAR
 """
-
+from __future__ import print_function
 
 from datetime import datetime
 import itertools
@@ -31,8 +31,8 @@ SERVICE_URL = 'https://geomag.usgs.gov/baselines/observation.json.php'
 # parse observatory and year arguments
 if len(sys.argv) != 3:
     cmd = sys.argv[0]
-    print >> sys.stderr, 'Usage:   {} OBSERVATORY YEAR'.format(cmd)
-    print >> sys.stderr, 'Example: {} BOU 2016'.format(cmd)
+    print('Usage:   {} OBSERVATORY YEAR'.format(cmd), file=sys.stderr)
+    print('Example: {} BOU 2016'.format(cmd), file=sys.stderr)
     sys.exit(1)
 
 OBSERVATORY = sys.argv[1]
@@ -47,14 +47,14 @@ url = SERVICE_URL + '?' + '&'.join([
 ])
 
 try:
-    print >> sys.stderr, 'Loading data from web service\n\t{}'.format(url)
+    print('Loading data from web service\n\t{}'.format(url), file=sys.stderr)
     response = urllib2.urlopen(url,
         # allow environment certificate bundle override
         cafile=os.environ.get('SSL_CERT_FILE'))
     data = response.read()
     observations = json.loads(data)
-except Exception, e:
-    print >> sys.stderr, 'Error loading data ({})'.format(str(e))
+except Exception as e:
+    print('Error loading data ({})'.format(str(e)), file=sys.stderr)
     sys.exit(1)
 
 
@@ -111,7 +111,7 @@ calfile.append('')
 
 # write calfile
 filename = FILENAME_FORMAT.format(OBSERVATORY=OBSERVATORY, YEAR=YEAR)
-print >> sys.stderr, 'Writing cal file to {}'.format(filename)
+print('Writing cal file to {}'.format(filename), file=sys.stderr)
 with open(filename, 'wb', -1) as f:
     f.write(os.linesep.join(calfile))
 

--- a/bin/monitor.py
+++ b/bin/monitor.py
@@ -160,21 +160,21 @@ def print_html_header(starttime, endtime, title):
     title: string
         The title passed in by the user
     """
-    print '<!DOCTYPE html>\n' + \
-    '<html>\n' + \
-        '<head>\n' + \
-            '<title> %s \n to %s \n</title>' % \
-                    (format_time(starttime), format_time(endtime)) + \
-        '</head>\n' + \
-        '<body>\n' + \
-            '<style type="text/css">\n' + \
-                'table {border-collapse: collapse;}\n' + \
-                'th {border:1px solid black; padding: 2px;}\n' + \
-                'td {text-align:center;}\n' + \
-            '</style>\n' +\
-            title + '<br>\n'\
-            '%s to %s ' % \
-                (format_time(starttime), format_time(endtime))
+    print('<!DOCTYPE html>\n' +
+        '<html>\n' +
+            '<head>\n' +
+                '<title> %s \n to %s \n</title>' %
+                        (format_time(starttime), format_time(endtime)) +
+            '</head>\n' +
+            '<body>\n' +
+                '<style type="text/css">\n' +
+                    'table {border-collapse: collapse;}\n' +
+                    'th {border:1px solid black; padding: 2px;}\n' +
+                    'td {text-align:center;}\n' +
+                '</style>\n' +
+                title + '<br>\n'
+                '%s to %s ' %
+                    (format_time(starttime), format_time(endtime)))
 
 
 def print_observatories(args):
@@ -265,9 +265,9 @@ def print_observatories(args):
                     '%s %ss<br>\n' % (warning, interval)
         summary_table += table_end
         if print_it:
-            print summary_header
-            print summary_table
-            print gap_details
+            print(summary_header)
+            print(summary_table)
+            print(gap_details)
 
     return warning_issued
 
@@ -287,8 +287,8 @@ def main(args):
     print_html_header(args.starttime, args.endtime, args.title)
 
     warning_issued = print_observatories(args)
-    print '</body>\n' + \
-          '</html>\n'
+    print('</body>\n' +
+          '</html>\n')
 
     sys.exit(warning_issued)
 

--- a/geomagio/Controller.py
+++ b/geomagio/Controller.py
@@ -1,5 +1,5 @@
 """Controller class for geomag algorithms"""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import argparse
 import sys
@@ -207,8 +207,8 @@ class Controller(object):
         if options.update_limit != 0:
             if update_count >= options.update_limit:
                 return
-        print >> sys.stderr, 'checking gaps', \
-                options.starttime, options.endtime
+        print('checking gaps', options.starttime, options.endtime,
+            file=sys.stderr)
         algorithm = self._algorithm
         input_channels = options.inchannels or \
                 algorithm.get_input_channels()
@@ -254,8 +254,8 @@ class Controller(object):
             # fill gap
             options.starttime = output_gap[0]
             options.endtime = output_gap[1]
-            print >> sys.stderr, 'processing', \
-                    options.starttime, options.endtime
+            print('processing', options.starttime, options.endtime,
+                file=sys.stderr)
             self.run(options, input_timeseries)
 
 
@@ -470,12 +470,12 @@ def main(args):
         usingDeprecated = True
 
     if usingDeprecated:
-        print >> sys.stderr, 'WARNING: you are using deprecated arguments,' + \
-                ' please update your usage'
+        print('WARNING: you are using deprecated arguments,' +
+              ' please update your usage', file=sys.stderr)
     # TODO check for unused arguments.
 
     # make sure observatory is a tuple
-    if isinstance(args.observatory, (str, unicode)):
+    if isinstance(args.observatory, (str, str)):
         args.observatory = (args.observatory,)
 
     if args.observatory_foreach:

--- a/geomagio/Controller.py
+++ b/geomagio/Controller.py
@@ -1,5 +1,6 @@
 """Controller class for geomag algorithms"""
 from __future__ import absolute_import, print_function
+from builtins import str as unicode
 
 import argparse
 import sys
@@ -475,7 +476,7 @@ def main(args):
     # TODO check for unused arguments.
 
     # make sure observatory is a tuple
-    if isinstance(args.observatory, (str, str)):
+    if isinstance(args.observatory, (str, unicode)):
         args.observatory = (args.observatory,)
 
     if args.observatory_foreach:

--- a/geomagio/Controller.py
+++ b/geomagio/Controller.py
@@ -1,23 +1,23 @@
 """Controller class for geomag algorithms"""
-
+from __future__ import absolute_import
 
 import argparse
 import sys
 from obspy.core import Stream, UTCDateTime
-from algorithm import algorithms
-from PlotTimeseriesFactory import PlotTimeseriesFactory
-from StreamTimeseriesFactory import StreamTimeseriesFactory
-import TimeseriesUtility
+from .algorithm import algorithms
+from .PlotTimeseriesFactory import PlotTimeseriesFactory
+from .StreamTimeseriesFactory import StreamTimeseriesFactory
+from . import TimeseriesUtility
 
 # factory packages
-import binlog
-import edge
-import iaga2002
-import pcdcp
-import imfv122
-import imfv283
-import temperature
-import vbf
+from . import binlog
+from . import edge
+from . import iaga2002
+from . import pcdcp
+from . import imfv122
+from . import imfv283
+from . import temperature
+from . import vbf
 
 
 class Controller(object):

--- a/geomagio/PlotTimeseriesFactory.py
+++ b/geomagio/PlotTimeseriesFactory.py
@@ -1,6 +1,8 @@
 """Abstract Timeseries Factory Interface."""
+from __future__ import absolute_import
+
 from obspy.core import Stream
-from TimeseriesFactory import TimeseriesFactory
+from .TimeseriesFactory import TimeseriesFactory
 
 
 class PlotTimeseriesFactory(TimeseriesFactory):

--- a/geomagio/StreamConverter.py
+++ b/geomagio/StreamConverter.py
@@ -6,10 +6,11 @@ Geo: Based on Geographic North.  X, Y, Z, F
 Obs: Based on the observatories orientaion. H, E, Z, F, d0
 Mag: Based on Magnetic North. H, D, Z, F
 """
+from __future__ import absolute_import
 
 import numpy
 import obspy.core
-import ChannelConverter
+from . import ChannelConverter
 
 
 def get_geo_from_mag(mag):

--- a/geomagio/StreamTimeseriesFactory.py
+++ b/geomagio/StreamTimeseriesFactory.py
@@ -1,6 +1,7 @@
 """Stream wrapper for TimeseriesFactory."""
+from __future__ import absolute_import
 
-from TimeseriesFactory import TimeseriesFactory
+from .TimeseriesFactory import TimeseriesFactory
 
 
 class StreamTimeseriesFactory(TimeseriesFactory):

--- a/geomagio/TimeseriesFactory.py
+++ b/geomagio/TimeseriesFactory.py
@@ -1,5 +1,5 @@
 """Abstract Timeseries Factory Interface."""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import numpy
 import obspy.core
@@ -120,8 +120,8 @@ class TimeseriesFactory(object):
             except NotImplementedError:
                 raise NotImplementedError('"get_timeseries" not implemented')
             except Exception as e:
-                print >> sys.stderr, "Error parsing data: " + str(e)
-                print >> sys.stderr, data
+                print("Error parsing data: " + str(e), file=sys.stderr)
+                print(data, file=sys.stderr)
         if channels is not None:
             filtered = obspy.core.Stream()
             for channel in channels:

--- a/geomagio/TimeseriesFactory.py
+++ b/geomagio/TimeseriesFactory.py
@@ -1,11 +1,13 @@
 """Abstract Timeseries Factory Interface."""
+from __future__ import absolute_import
+
 import numpy
 import obspy.core
 import os
 import sys
-from TimeseriesFactoryException import TimeseriesFactoryException
-import TimeseriesUtility
-import Util
+from .TimeseriesFactoryException import TimeseriesFactoryException
+from . import TimeseriesUtility
+from . import Util
 
 
 class TimeseriesFactory(object):

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -47,7 +47,7 @@ def get_trace_gaps(trace):
     starttime = stats.starttime
     length = len(data)
     delta = stats.delta
-    for i in xrange(0, length):
+    for i in range(0, length):
         if numpy.isnan(data[i]):
             if gap is None:
                 # start of a gap

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -1,4 +1,5 @@
 """Timeseries Utilities"""
+from builtins import range
 import numpy
 import obspy.core
 

--- a/geomagio/Util.py
+++ b/geomagio/Util.py
@@ -2,7 +2,7 @@ import pycurl
 import numpy
 import os
 from obspy.core import Stats, Trace
-from StringIO import StringIO
+from io import StringIO
 
 
 class ObjectView(object):

--- a/geomagio/__init__.py
+++ b/geomagio/__init__.py
@@ -1,16 +1,18 @@
 """
 Geomag Algorithm Module
 """
-import ChannelConverter
-import StreamConverter
+from __future__ import absolute_import
 
-from Controller import Controller
-from ObservatoryMetadata import ObservatoryMetadata
-from PlotTimeseriesFactory import PlotTimeseriesFactory
-from TimeseriesFactory import TimeseriesFactory
-from TimeseriesFactoryException import TimeseriesFactoryException
-import TimeseriesUtility
-import Util
+from . import ChannelConverter
+from . import StreamConverter
+
+from .Controller import Controller
+from .ObservatoryMetadata import ObservatoryMetadata
+from .PlotTimeseriesFactory import PlotTimeseriesFactory
+from .TimeseriesFactory import TimeseriesFactory
+from .TimeseriesFactoryException import TimeseriesFactoryException
+from . import TimeseriesUtility
+from . import Util
 
 __all__ = [
     'ChannelConverter',

--- a/geomagio/algorithm/AdjustedAlgorithm.py
+++ b/geomagio/algorithm/AdjustedAlgorithm.py
@@ -2,7 +2,9 @@
     related geographic coordinate system, by using transformations generated
     from absolute, baseline measurements.
 """
-from Algorithm import Algorithm
+from __future__ import absolute_import
+
+from .Algorithm import Algorithm
 import json
 import numpy as np
 from obspy.core import Stream, Stats

--- a/geomagio/algorithm/DeltaFAlgorithm.py
+++ b/geomagio/algorithm/DeltaFAlgorithm.py
@@ -1,9 +1,10 @@
 """Algorithm that creates a deltaf
 
 """
+from __future__ import absolute_import
 
-from Algorithm import Algorithm
-from AlgorithmException import AlgorithmException
+from .Algorithm import Algorithm
+from .AlgorithmException import AlgorithmException
 from .. import StreamConverter
 
 # List of channels by geomagnetic observatory orientation.

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -11,10 +11,11 @@
     Use of fmin_l_bfgs_b to estimate parameters inspired by Andre Queiroz:
         https://gist.github.com/andrequeiroz/5888967
 """
+from __future__ import absolute_import
 
 from .. import StreamConverter
-from Algorithm import Algorithm
-from AlgorithmException import AlgorithmException
+from .Algorithm import Algorithm
+from .AlgorithmException import AlgorithmException
 import json
 import numpy as np
 from obspy.core import Stream, UTCDateTime

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -471,13 +471,13 @@ class SqDistAlgorithm(Algorithm):
 
                 # distribute error correction across range of seasonal
                 # corrections according to weights calculated above
-                s[i + m] = s[i] + gamma * (1 - alpha) * et * weights[nts / 2]
-                s[i + m - nts / 2:i + m] = (s[i + m - nts / 2:i + m] +
+                s[i + m] = s[i] + gamma * (1 - alpha) * et * weights[nts // 2]
+                s[i + m - nts // 2:i + m] = (s[i + m - nts // 2:i + m] +
                                             gamma * (1 - alpha) * et *
-                                            weights[:nts / 2])
-                s[i + 1:i + nts / 2 + 1] = (s[i + 1:i + nts / 2 + 1] +
+                                            weights[:nts // 2])
+                s[i + 1:i + nts // 2 + 1] = (s[i + 1:i + nts // 2 + 1] +
                                             gamma * (1 - alpha) * et *
-                                            weights[nts / 2 + 1:])
+                                            weights[nts // 2 + 1:])
 
                 # update l and b using equation-error formulation
                 l = l + phi * b + alpha * et

--- a/geomagio/algorithm/XYZAlgorithm.py
+++ b/geomagio/algorithm/XYZAlgorithm.py
@@ -2,9 +2,10 @@
     related coordinate system.
 
 """
+from __future__ import absolute_import
 
-from Algorithm import Algorithm
-from AlgorithmException import AlgorithmException
+from .Algorithm import Algorithm
+from .AlgorithmException import AlgorithmException
 from .. import StreamConverter
 
 # List of channels by geomagnetic observatory orientation.

--- a/geomagio/algorithm/__init__.py
+++ b/geomagio/algorithm/__init__.py
@@ -1,15 +1,16 @@
 """
 Geomag Algorithms module
 """
+from __future__ import absolute_import
 
 # base classes
-from Algorithm import Algorithm
-from AlgorithmException import AlgorithmException
+from .Algorithm import Algorithm
+from .AlgorithmException import AlgorithmException
 # algorithms
-from AdjustedAlgorithm import AdjustedAlgorithm
-from DeltaFAlgorithm import DeltaFAlgorithm
-from SqDistAlgorithm import SqDistAlgorithm
-from XYZAlgorithm import XYZAlgorithm
+from .AdjustedAlgorithm import AdjustedAlgorithm
+from .DeltaFAlgorithm import DeltaFAlgorithm
+from .SqDistAlgorithm import SqDistAlgorithm
+from .XYZAlgorithm import XYZAlgorithm
 
 
 # algorithms is used by Controller to auto generate arguments

--- a/geomagio/binlog/BinLogFactory.py
+++ b/geomagio/binlog/BinLogFactory.py
@@ -1,7 +1,8 @@
 """Factory that creates BinLog Files."""
+from __future__ import absolute_import
 
 from ..TimeseriesFactory import TimeseriesFactory
-from BinLogWriter import BinLogWriter
+from .BinLogWriter import BinLogWriter
 
 
 class BinLogFactory(TimeseriesFactory):

--- a/geomagio/binlog/BinLogWriter.py
+++ b/geomagio/binlog/BinLogWriter.py
@@ -118,7 +118,7 @@ class BinLogWriter(object):
         starttime = float(traces[0].stats.starttime)
         delta = traces[0].stats.delta
 
-        for i in xrange(len(traces[0].data)):
+        for i in range(len(traces[0].data)):
             self._format_values(
                 datetime.utcfromtimestamp(starttime + i * delta),
                 (t.data[i] for t in traces))

--- a/geomagio/binlog/BinLogWriter.py
+++ b/geomagio/binlog/BinLogWriter.py
@@ -1,6 +1,6 @@
 
 import numpy
-from cStringIO import StringIO
+from io import StringIO
 from datetime import datetime
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactoryException import TimeseriesFactoryException

--- a/geomagio/binlog/BinLogWriter.py
+++ b/geomagio/binlog/BinLogWriter.py
@@ -1,3 +1,4 @@
+from builtins import range
 
 import numpy
 from io import StringIO

--- a/geomagio/binlog/StreamBinLogFactory.py
+++ b/geomagio/binlog/StreamBinLogFactory.py
@@ -1,6 +1,7 @@
 """Factory to load BinLog files from an input StreamBinLogFactory."""
+from __future__ import absolute_import
 
-from BinLogFactory import BinLogFactory
+from .BinLogFactory import BinLogFactory
 
 
 class StreamBinLogFactory(BinLogFactory):

--- a/geomagio/binlog/__init__.py
+++ b/geomagio/binlog/__init__.py
@@ -1,9 +1,10 @@
 """IO Module for BinLog Format
 """
+from __future__ import absolute_import
 
-from BinLogFactory import BinLogFactory
-from StreamBinLogFactory import StreamBinLogFactory
-from BinLogWriter import BinLogWriter
+from .BinLogFactory import BinLogFactory
+from .StreamBinLogFactory import StreamBinLogFactory
+from .BinLogWriter import BinLogWriter
 
 
 __all__ = [

--- a/geomagio/edge/EdgeFactory.py
+++ b/geomagio/edge/EdgeFactory.py
@@ -8,9 +8,10 @@ to take advantage of it's newer realtime abilities.
 
 Edge is the USGS earthquake hazard centers replacement for earthworm.
 """
+from __future__ import absolute_import
 
 import sys
-import StringIO
+from io import StringIO
 import numpy
 import numpy.ma
 import obspy.core
@@ -23,13 +24,13 @@ from datetime import datetime
 #     from obspy import earthworm
 
 # use local version of earthworm client to test memory leak fix
-import client as earthworm
+from . import client as earthworm
 
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactory import TimeseriesFactory
 from ..TimeseriesFactoryException import TimeseriesFactoryException
 from ..ObservatoryMetadata import ObservatoryMetadata
-from RawInputClient import RawInputClient
+from .RawInputClient import RawInputClient
 
 
 class EdgeFactory(TimeseriesFactory):
@@ -140,7 +141,7 @@ class EdgeFactory(TimeseriesFactory):
         # need this until https://github.com/obspy/obspy/pull/1179
         # replace stdout
         original_stdout = sys.stdout
-        temp_stdout = StringIO.StringIO()
+        temp_stdout = StringIO()
         try:
             sys.stdout = temp_stdout
             # get the timeseries

--- a/geomagio/edge/RawInputClient.py
+++ b/geomagio/edge/RawInputClient.py
@@ -1,3 +1,4 @@
+from builtins import range
 
 import socket  # noqa
 import struct

--- a/geomagio/edge/RawInputClient.py
+++ b/geomagio/edge/RawInputClient.py
@@ -184,7 +184,7 @@ class RawInputClient():
             raise TimeseriesFactoryException(
                     'Unsupported interval for RawInputClient')
 
-        for i in xrange(0, totalsamps, nsamp):
+        for i in range(0, totalsamps, nsamp):
             if totalsamps - i < nsamp:
                 endsample = totalsamps
             else:

--- a/geomagio/edge/RawInputClient.py
+++ b/geomagio/edge/RawInputClient.py
@@ -222,7 +222,7 @@ class RawInputClient():
                 self._open_socket()
             self.socket.sendall(buf)
             self.sequence += 1
-        except socket.error, v:
+        except socket.error as v:
             error = 'Socket error %d' % v[0]
             sys.stderr.write(error)
             raise TimeseriesFactoryException(error)
@@ -412,7 +412,7 @@ class RawInputClient():
                 newsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 newsocket.connect((self.host, self.port))
                 done = True
-            except socket.error, v:
+            except socket.error as v:
                 sys.stderr.write('Could not connect to socket, trying again')
                 sys.stderr.write('sockect error %d' % v[0])
                 sleep(1)

--- a/geomagio/edge/__init__.py
+++ b/geomagio/edge/__init__.py
@@ -1,9 +1,10 @@
 """IO Module for Edge Format
 """
+from __future__ import absolute_import
 
-from EdgeFactory import EdgeFactory
-from LocationCode import LocationCode
-from RawInputClient import RawInputClient
+from .EdgeFactory import EdgeFactory
+from .LocationCode import LocationCode
+from .RawInputClient import RawInputClient
 
 __all__ = [
     'EdgeFactory',

--- a/geomagio/iaga2002/IAGA2002Factory.py
+++ b/geomagio/iaga2002/IAGA2002Factory.py
@@ -58,7 +58,7 @@ class IAGA2002Factory(TimeseriesFactory):
         endtime = obspy.core.UTCDateTime(parser.times[-1])
         data = parser.data
         stream = obspy.core.Stream()
-        length = len(data[data.keys()[0]])
+        length = len(data[list(data)[0]])
         if starttime != endtime:
             rate = (length - 1) / (endtime - starttime)
         else:

--- a/geomagio/iaga2002/IAGA2002Factory.py
+++ b/geomagio/iaga2002/IAGA2002Factory.py
@@ -1,10 +1,11 @@
 """Factory that loads IAGA2002 Files."""
+from __future__ import absolute_import
 
 import obspy.core
 from .. import ChannelConverter
 from ..TimeseriesFactory import TimeseriesFactory
-from IAGA2002Parser import IAGA2002Parser
-from IAGA2002Writer import IAGA2002Writer
+from .IAGA2002Parser import IAGA2002Parser
+from .IAGA2002Writer import IAGA2002Writer
 
 
 # pattern for iaga 2002 file names

--- a/geomagio/iaga2002/IAGA2002Writer.py
+++ b/geomagio/iaga2002/IAGA2002Writer.py
@@ -1,12 +1,13 @@
+from __future__ import absolute_import
 
-from cStringIO import StringIO
+from io import StringIO
 from datetime import datetime
 import numpy
 import textwrap
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactoryException import TimeseriesFactoryException
 from ..Util import create_empty_trace
-import IAGA2002Parser
+from . import IAGA2002Parser
 
 
 class IAGA2002Writer(object):

--- a/geomagio/iaga2002/IAGA2002Writer.py
+++ b/geomagio/iaga2002/IAGA2002Writer.py
@@ -216,7 +216,7 @@ class IAGA2002Writer(object):
         traces = [timeseries.select(channel=c)[0] for c in channels]
         starttime = float(traces[0].stats.starttime)
         delta = traces[0].stats.delta
-        for i in xrange(len(traces[0].data)):
+        for i in range(len(traces[0].data)):
             buf.append(self._format_values(
                 datetime.utcfromtimestamp(starttime + i * delta),
                 (t.data[i] for t in traces)))

--- a/geomagio/iaga2002/IAGA2002Writer.py
+++ b/geomagio/iaga2002/IAGA2002Writer.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 
 from io import StringIO
 from datetime import datetime

--- a/geomagio/iaga2002/StreamIAGA2002Factory.py
+++ b/geomagio/iaga2002/StreamIAGA2002Factory.py
@@ -1,6 +1,7 @@
 """Factory to load IAGA2002 files from an input StreamIAGA2002Factory."""
+from __future__ import absolute_import
 
-from IAGA2002Factory import IAGA2002Factory
+from .IAGA2002Factory import IAGA2002Factory
 
 
 class StreamIAGA2002Factory(IAGA2002Factory):

--- a/geomagio/iaga2002/__init__.py
+++ b/geomagio/iaga2002/__init__.py
@@ -3,11 +3,12 @@
 Based on documentation at:
   http://www.ngdc.noaa.gov/IAGA/vdat/iagaformat.html
 """
+from __future__ import absolute_import
 
-from IAGA2002Factory import IAGA2002Factory
-from StreamIAGA2002Factory import StreamIAGA2002Factory
-from IAGA2002Parser import IAGA2002Parser
-from IAGA2002Writer import IAGA2002Writer
+from .IAGA2002Factory import IAGA2002Factory
+from .StreamIAGA2002Factory import StreamIAGA2002Factory
+from .IAGA2002Parser import IAGA2002Parser
+from .IAGA2002Writer import IAGA2002Writer
 
 
 __all__ = [

--- a/geomagio/imfv122/IMFV122Factory.py
+++ b/geomagio/imfv122/IMFV122Factory.py
@@ -1,9 +1,10 @@
 """Factory that loads IMFV122 Files."""
+from __future__ import absolute_import
 
 import obspy.core
 from .. import ChannelConverter
 from ..TimeseriesFactory import TimeseriesFactory
-from IMFV122Parser import IMFV122Parser
+from .IMFV122Parser import IMFV122Parser
 
 
 class IMFV122Factory(TimeseriesFactory):

--- a/geomagio/imfv122/StreamIMFV122Factory.py
+++ b/geomagio/imfv122/StreamIMFV122Factory.py
@@ -1,6 +1,7 @@
 """Factory to load IMFV122 files from an input stream."""
+from __future__ import absolute_import
 
-from IMFV122Factory import IMFV122Factory
+from .IMFV122Factory import IMFV122Factory
 
 
 class StreamIMFV122Factory(IMFV122Factory):

--- a/geomagio/imfv122/__init__.py
+++ b/geomagio/imfv122/__init__.py
@@ -3,10 +3,11 @@
 Based on documentation at:
   http://www.intermagnet.org/data-donnee/formats/imfv122-eng.php
 """
+from __future__ import absolute_import
 
-from IMFV122Factory import IMFV122Factory
-from IMFV122Parser import IMFV122Parser
-from StreamIMFV122Factory import StreamIMFV122Factory
+from .IMFV122Factory import IMFV122Factory
+from .IMFV122Parser import IMFV122Parser
+from .StreamIMFV122Factory import StreamIMFV122Factory
 
 
 __all__ = [

--- a/geomagio/imfv283/GOESIMFV283Factory.py
+++ b/geomagio/imfv283/GOESIMFV283Factory.py
@@ -1,5 +1,5 @@
 """Factory to load IMFV283 files from an input StreamIMFV283Factory."""
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 from .IMFV283Factory import IMFV283Factory
 import subprocess
@@ -69,8 +69,8 @@ class GOESIMFV283Factory(IMFV283Factory):
         timeseries.trim(starttime, endtime)
         # output the number of points we read for logging
         if len(timeseries):
-            print >> sys.stderr, "Read %s points from %s" % \
-                (timeseries[0].stats.npts, observatory)
+            print("Read %s points from %s" % (timeseries[0].stats.npts,
+                observatory), file=sys.stderr)
 
         self._post_process(timeseries)
         if observatory is not None:
@@ -125,7 +125,7 @@ class GOESIMFV283Factory(IMFV283Factory):
         self._fill_criteria_file(starttime, endtime, observatory)
 
         for server in self.server:
-            print >> sys.stderr, server
+            print(server, file=sys.stderr)
             proc = subprocess.Popen(
                     [self.getdcpmessages,
                     '-h', server,
@@ -135,11 +135,10 @@ class GOESIMFV283Factory(IMFV283Factory):
                     '-t', '60',
                     '-n'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (output, error) = proc.communicate()
-            print >> sys.stderr, error
+            print(error, file=sys.stderr)
             if error.find(self.javaerror) >= 0:
-                print >> sys.stderr, \
-                        'Error: could not connect to %s' % \
-                        server
+                print('Error: could not connect to %s' % server,
+                    file=sys.stderr)
                 continue
             break
 

--- a/geomagio/imfv283/GOESIMFV283Factory.py
+++ b/geomagio/imfv283/GOESIMFV283Factory.py
@@ -1,6 +1,7 @@
 """Factory to load IMFV283 files from an input StreamIMFV283Factory."""
+from __future__ import absolute_import
 
-from IMFV283Factory import IMFV283Factory
+from .IMFV283Factory import IMFV283Factory
 import subprocess
 import sys
 from obspy.core import Stream

--- a/geomagio/imfv283/IMFV283Factory.py
+++ b/geomagio/imfv283/IMFV283Factory.py
@@ -1,9 +1,10 @@
 """Factory that loads IAGA2002 Files."""
+from __future__ import absolute_import
 
 import numpy
 from .. import ChannelConverter
 from ..TimeseriesFactory import TimeseriesFactory
-from IMFV283Parser import IMFV283Parser
+from .IMFV283Parser import IMFV283Parser
 from ..ObservatoryMetadata import ObservatoryMetadata
 
 

--- a/geomagio/imfv283/IMFV283Parser.py
+++ b/geomagio/imfv283/IMFV283Parser.py
@@ -334,7 +334,7 @@ class IMFV283Parser(object):
             byte1 = ord(msg[offset + ness_byte])
 
             goes_value1 = (byte3 & 0x3F) + ((byte2 & 0x3) * 0x40)
-            goes_value2 = ((byte2 / 0x4) & 0xF) + ((byte1 & 0xF) * 0x10)
+            goes_value2 = ((byte2 // 0x4) & 0xF) + ((byte1 & 0xF) * 0x10)
 
             # swap the bytes depending on domsat information.
             if domsat['swap_hdr'] and cnt <= 11 or \

--- a/geomagio/imfv283/IMFV283Parser.py
+++ b/geomagio/imfv283/IMFV283Parser.py
@@ -1,5 +1,6 @@
 """Parsing methods for the IMFV283 Format."""
 from __future__ import absolute_import
+from builtins import range
 
 import math
 import numpy

--- a/geomagio/imfv283/IMFV283Parser.py
+++ b/geomagio/imfv283/IMFV283Parser.py
@@ -1,11 +1,13 @@
 """Parsing methods for the IMFV283 Format."""
+from __future__ import absolute_import
+
 import math
 import numpy
 import sys
 import obspy
 from obspy.core import UTCDateTime
 
-import imfv283_codes
+from . import imfv283_codes
 
 # values that represent missing data points in IAGA2002
 DEAD_VALUE = 65535

--- a/geomagio/imfv283/IMFV283Parser.py
+++ b/geomagio/imfv283/IMFV283Parser.py
@@ -118,7 +118,7 @@ class IMFV283Parser(object):
             parse_data[channel] = []
 
         bytecount = 30
-        for cnt in xrange(0, 12):
+        for cnt in range(0, 12):
             # get data in 2 byte pairs as integers.
             d1 = 0x100 * data[bytecount] + data[bytecount + 1]
             d2 = 0x100 * data[bytecount + 2] + data[bytecount + 3]
@@ -285,7 +285,7 @@ class IMFV283Parser(object):
         scale = goes_header['scale']
         offset = goes_header['offset']
         orientation = goes_header['orient']
-        for channel, loc in zip(CHANNELS[orientation], xrange(0, 4)):
+        for channel, loc in zip(CHANNELS[orientation], range(0, 4)):
             stats = obspy.core.Stats()
             stats.channel = channel
             stats.sampling_rate = 0.0166666666667
@@ -327,7 +327,7 @@ class IMFV283Parser(object):
         else:
             offset = HEADER_SIZE
 
-        for cnt in xrange(0, 63):
+        for cnt in range(0, 63):
             # Convert 3 byte "pair" into ordinal values for manipulation.
             byte3 = ord(msg[offset + ness_byte + 2])
             byte2 = ord(msg[offset + ness_byte + 1])

--- a/geomagio/imfv283/StreamIMFV283Factory.py
+++ b/geomagio/imfv283/StreamIMFV283Factory.py
@@ -1,6 +1,7 @@
 """Factory to load IMFV283 files from an input StreamIMFV283Factory."""
+from __future__ import absolute_import
 
-from IMFV283Factory import IMFV283Factory
+from .IMFV283Factory import IMFV283Factory
 
 
 class StreamIMFV283Factory(IMFV283Factory):

--- a/geomagio/imfv283/__init__.py
+++ b/geomagio/imfv283/__init__.py
@@ -3,11 +3,12 @@
 Based on documentation at:
   http://http://www.intermagnet.org/data-donnee/formats/imfv283e-eng.php
 """
+from __future__ import absolute_import
 
-from GOESIMFV283Factory import GOESIMFV283Factory
-from IMFV283Factory import IMFV283Factory
-from StreamIMFV283Factory import StreamIMFV283Factory
-from IMFV283Parser import IMFV283Parser
+from .GOESIMFV283Factory import GOESIMFV283Factory
+from .IMFV283Factory import IMFV283Factory
+from .StreamIMFV283Factory import StreamIMFV283Factory
+from .IMFV283Parser import IMFV283Parser
 
 
 __all__ = [

--- a/geomagio/pcdcp/PCDCPFactory.py
+++ b/geomagio/pcdcp/PCDCPFactory.py
@@ -69,7 +69,7 @@ class PCDCPFactory(TimeseriesFactory):
                         minute=endMinute)
 
         data = parser.data
-        length = len(data[data.keys()[0]])
+        length = len(data[list(data)[0]])
         rate = (length - 1) / (endtime - starttime)
         stream = obspy.core.Stream()
 

--- a/geomagio/pcdcp/PCDCPFactory.py
+++ b/geomagio/pcdcp/PCDCPFactory.py
@@ -1,10 +1,11 @@
 """Factory that loads PCDCP Files."""
+from __future__ import absolute_import
 
 import obspy.core
 from .. import ChannelConverter
 from ..TimeseriesFactory import TimeseriesFactory
-from PCDCPParser import PCDCPParser
-from PCDCPWriter import PCDCPWriter
+from .PCDCPParser import PCDCPParser
+from .PCDCPWriter import PCDCPWriter
 
 
 # pattern for pcdcp file names

--- a/geomagio/pcdcp/PCDCPWriter.py
+++ b/geomagio/pcdcp/PCDCPWriter.py
@@ -110,7 +110,7 @@ class PCDCPWriter(object):
         starttime = float(traces[0].stats.starttime)
         delta = traces[0].stats.delta
 
-        for i in xrange(len(traces[0].data)):
+        for i in range(len(traces[0].data)):
             buf.append(self._format_values(
                 datetime.utcfromtimestamp(starttime + i * delta),
                 (t.data[i] for t in traces), stats))

--- a/geomagio/pcdcp/PCDCPWriter.py
+++ b/geomagio/pcdcp/PCDCPWriter.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import range
 
 import numpy
 from . import PCDCPParser

--- a/geomagio/pcdcp/PCDCPWriter.py
+++ b/geomagio/pcdcp/PCDCPWriter.py
@@ -1,7 +1,8 @@
+from __future__ import absolute_import
 
 import numpy
-import PCDCPParser
-from cStringIO import StringIO
+from . import PCDCPParser
+from io import StringIO
 from datetime import datetime
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactoryException import TimeseriesFactoryException

--- a/geomagio/pcdcp/StreamPCDCPFactory.py
+++ b/geomagio/pcdcp/StreamPCDCPFactory.py
@@ -1,6 +1,7 @@
 """Factory to load PCDCP files from an input StreamPCDCPFactory."""
+from __future__ import absolute_import
 
-from PCDCPFactory import PCDCPFactory
+from .PCDCPFactory import PCDCPFactory
 
 
 class StreamPCDCPFactory(PCDCPFactory):

--- a/geomagio/pcdcp/__init__.py
+++ b/geomagio/pcdcp/__init__.py
@@ -1,10 +1,11 @@
 """IO Module for PCDCP Format
 """
+from __future__ import absolute_import
 
-from PCDCPFactory import PCDCPFactory
-from StreamPCDCPFactory import StreamPCDCPFactory
-from PCDCPParser import PCDCPParser
-from PCDCPWriter import PCDCPWriter
+from .PCDCPFactory import PCDCPFactory
+from .StreamPCDCPFactory import StreamPCDCPFactory
+from .PCDCPParser import PCDCPParser
+from .PCDCPWriter import PCDCPWriter
 
 
 __all__ = [

--- a/geomagio/temperature/StreamTEMPFactory.py
+++ b/geomagio/temperature/StreamTEMPFactory.py
@@ -1,6 +1,7 @@
 """Factory to load temp/volt files from an input StreamTEMPFactory."""
+from __future__ import absolute_import
 
-from TEMPFactory import TEMPFactory
+from .TEMPFactory import TEMPFactory
 
 
 class StreamTEMPFactory(TEMPFactory):

--- a/geomagio/temperature/TEMPFactory.py
+++ b/geomagio/temperature/TEMPFactory.py
@@ -1,7 +1,8 @@
 """Factory that loads temp/volt Files."""
+from __future__ import absolute_import
 
 from ..TimeseriesFactory import TimeseriesFactory
-from TEMPWriter import TEMPWriter
+from .TEMPWriter import TEMPWriter
 
 
 # pattern for temp file names

--- a/geomagio/temperature/TEMPWriter.py
+++ b/geomagio/temperature/TEMPWriter.py
@@ -94,7 +94,7 @@ class TEMPWriter(object):
         starttime = float(traces[0].stats.starttime)
         delta = traces[0].stats.delta
 
-        for i in xrange(len(traces[0].data)):
+        for i in range(len(traces[0].data)):
             buf.append(self._format_values(
                 datetime.utcfromtimestamp(starttime + i * delta),
                 (t.data[i] for t in traces)))

--- a/geomagio/temperature/TEMPWriter.py
+++ b/geomagio/temperature/TEMPWriter.py
@@ -1,3 +1,4 @@
+from builtins import range
 
 import numpy
 from io import StringIO

--- a/geomagio/temperature/TEMPWriter.py
+++ b/geomagio/temperature/TEMPWriter.py
@@ -1,6 +1,6 @@
 
 import numpy
-from cStringIO import StringIO
+from io import StringIO
 from datetime import datetime
 from .. import TimeseriesUtility
 from ..TimeseriesFactoryException import TimeseriesFactoryException

--- a/geomagio/temperature/__init__.py
+++ b/geomagio/temperature/__init__.py
@@ -1,9 +1,10 @@
 """IO Module for TEMP Format
 """
+from __future__ import absolute_import
 
-from TEMPFactory import TEMPFactory
-from StreamTEMPFactory import StreamTEMPFactory
-from TEMPWriter import TEMPWriter
+from .TEMPFactory import TEMPFactory
+from .StreamTEMPFactory import StreamTEMPFactory
+from .TEMPWriter import TEMPWriter
 
 
 __all__ = [

--- a/geomagio/vbf/StreamVBFFactory.py
+++ b/geomagio/vbf/StreamVBFFactory.py
@@ -1,6 +1,7 @@
 """Factory to load VBF files from an input StreamVBFFactory."""
+from __future__ import absolute_import
 
-from VBFFactory import VBFFactory
+from .VBFFactory import VBFFactory
 
 
 class StreamVBFFactory(VBFFactory):

--- a/geomagio/vbf/VBFFactory.py
+++ b/geomagio/vbf/VBFFactory.py
@@ -1,7 +1,8 @@
 """Factory that loads VBF Files."""
+from __future__ import absolute_import
 
 from ..TimeseriesFactory import TimeseriesFactory
-from VBFWriter import VBFWriter
+from .VBFWriter import VBFWriter
 
 
 # pattern for vbf file names

--- a/geomagio/vbf/VBFWriter.py
+++ b/geomagio/vbf/VBFWriter.py
@@ -1,6 +1,6 @@
 
 import numpy
-from cStringIO import StringIO
+from io import StringIO
 from datetime import datetime
 from .. import ChannelConverter, TimeseriesUtility
 from ..TimeseriesFactoryException import TimeseriesFactoryException

--- a/geomagio/vbf/VBFWriter.py
+++ b/geomagio/vbf/VBFWriter.py
@@ -99,7 +99,7 @@ class VBFWriter(object):
         starttime = float(traces[0].stats.starttime)
         delta = traces[0].stats.delta
 
-        for i in xrange(len(traces[0].data)):
+        for i in range(len(traces[0].data)):
             buf.append(self._format_values(
                 datetime.utcfromtimestamp(starttime + i * delta),
                 (t.data[i] for t in traces)))

--- a/geomagio/vbf/VBFWriter.py
+++ b/geomagio/vbf/VBFWriter.py
@@ -1,3 +1,4 @@
+from builtins import range
 
 import numpy
 from io import StringIO

--- a/geomagio/vbf/__init__.py
+++ b/geomagio/vbf/__init__.py
@@ -1,9 +1,10 @@
 """IO Module for VBF Format
 """
+from __future__ import absolute_import
 
-from VBFFactory import VBFFactory
-from StreamVBFFactory import StreamVBFFactory
-from VBFWriter import VBFWriter
+from .VBFFactory import VBFFactory
+from .StreamVBFFactory import StreamVBFFactory
+from .VBFWriter import VBFWriter
 
 
 __all__ = [

--- a/test/ObservatoryMetadata_test.py
+++ b/test/ObservatoryMetadata_test.py
@@ -67,5 +67,5 @@ def test_set_metadata():
     observatorymetadata.set_metadata(stats, 'BOU', 'MVH',
             'quasi-definitive', 'second')
     assert_equals(stats['declination_base'], 20000)
-    print stats
+    print(stats)
     assert_equals(stats['data_interval_type'], 'Average 1-Second')

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
+from __future__ import absolute_import
+
 from nose.tools import assert_equals
-from StreamConverter_test import __create_trace
+from .StreamConverter_test import __create_trace
 import numpy
 from geomagio import TimeseriesUtility
 from obspy.core import Stream, UTCDateTime


### PR DESCRIPTION
This pull request fixes #145 and adds support for Python 3.4 and 3.5. Changes are:
- Use absolute imports in all files
- Parentheses around print statements, and use `from __future__ import print_function` if writing to `sys.stderr` or printing multiple values
- Change `except` syntax from using comma to `as`
- Change `unicode` type to `str`
- Change `xrange` to `range`
- Import `StringIO` from `io`, not from `StringIO` or `cStringIO`
- Change dictionary keys function `data.keys()` to `list(data)` to get list of keys
- Change `/` to `//` whenever dividing integers