### PR TITLE
WIP: Refactor metadata

### DIFF
--- a/geomagio/metadata/README.md
+++ b/geomagio/metadata/README.md
@@ -1,0 +1,80 @@
+# Metadata
+
+
+## Structure
+
+Each `type` of metadata uses a separate folder,
+with one file per `object` being described.
+
+```
+geomagio/metadata/TYPE/OBJECT.py
+```
+
+Each file defines a `METADATA` variable,
+which consists of a list of dictionary objects
+that define different versions of metadata associated with an `OBJECT`.
+
+
+```
+"""OBJECT metadata file"""
+
+METADATA = [
+    {VERSION2}
+    {VERSION1}
+]
+```
+
+
+### Epochs (Versions)
+
+Each version represents the metadata for a given time interval.
+*Versions must appear in descending order (newest versions first).*
+
+
+The time interval is represented using the reserved properties
+`starttime` and `endtime`, which define the time interval that this version of
+metadata are valid.
+
+The interval can be represented using set notation as:
+    `[starttime, endtime)`
+
+- `starttime` - ISO8601 formatted string, or `None`
+
+    The time when this version of the metadata is first considered valid.
+
+    When this value is `None`,
+    it implies the metadata is valid for all times before `endtime`.
+
+- `endtime` - ISO8601 formatted string, or `None`
+
+    The time when this version of the metadata is no longer valid.
+
+    When this value is `None`,
+    it implies the metadata is valid for all times after `starttime`.
+
+#### Examples
+
+This example shows two versions of metadata:
+one for all times before `2016-01-01T00:00:00Z`
+    (some_value = 1),
+and one for all times after and including `2016-01-01T00:00:00Z`
+    (some_value = 2).
+
+```python
+METADATA = [
+    {
+        'starttime': '2016-01-01T00:00:00Z',
+        'endtime': None
+
+        # other properties
+        'some_value': 2
+    },
+    {
+        'starttime': None
+        'endtime': '2016-01-01T00:00:00Z'
+
+        # other properties
+        'some_value': 1
+    }
+]
+```

--- a/geomagio/metadata/__init__.py
+++ b/geomagio/metadata/__init__.py
@@ -1,0 +1,9 @@
+"""metadata module"""
+from __future__ import absolute_import
+
+from .observatory import get_observatory
+
+
+__all__ = [
+    'get_observatory'
+]

--- a/geomagio/metadata/observatory/BDT.py
+++ b/geomagio/metadata/observatory/BDT.py
@@ -1,0 +1,17 @@
+"""BDT Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Boulder Test',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '40.137',
+        'geodetic_longitude': '254.763',
+        'elevation': '1682',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 5527
+    }
+]

--- a/geomagio/metadata/observatory/BLC.py
+++ b/geomagio/metadata/observatory/BLC.py
@@ -1,0 +1,17 @@
+"""BLC Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Bake Lake',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '64.300',
+        'geodetic_longitude': '264.000',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/BOU.py
+++ b/geomagio/metadata/observatory/BOU.py
@@ -1,0 +1,17 @@
+"""BOU Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Boulder',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '40.137',
+        'geodetic_longitude': '254.763',
+        'elevation': '1682',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 5527
+    }
+]

--- a/geomagio/metadata/observatory/BRD.py
+++ b/geomagio/metadata/observatory/BRD.py
@@ -1,0 +1,17 @@
+"""BRD Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Brandon',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '49.600',
+        'geodetic_longitude': '262.900',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/BRT.py
+++ b/geomagio/metadata/observatory/BRT.py
@@ -1,0 +1,17 @@
+"""BRT Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Barrow Test',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '71.322',
+        'geodetic_longitude': '203.378',
+        'elevation': '10',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 16000
+    }
+]

--- a/geomagio/metadata/observatory/BRW.py
+++ b/geomagio/metadata/observatory/BRW.py
@@ -1,0 +1,17 @@
+"""BRW Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Barrow',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '71.322',
+        'geodetic_longitude': '203.378',
+        'elevation': '10',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 16000
+    }
+]

--- a/geomagio/metadata/observatory/BSL.py
+++ b/geomagio/metadata/observatory/BSL.py
@@ -1,0 +1,17 @@
+"""BSL Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Stennis Space Center',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '30.350',
+        'geodetic_longitude': '270.365',
+        'elevation': '8',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 1530
+    }
+]

--- a/geomagio/metadata/observatory/CBB.py
+++ b/geomagio/metadata/observatory/CBB.py
@@ -1,0 +1,17 @@
+"""CBB Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Cambridge Bay',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '69.200',
+        'geodetic_longitude': '255.000',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/CMO.py
+++ b/geomagio/metadata/observatory/CMO.py
@@ -1,0 +1,17 @@
+"""CMO Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'College',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '64.874',
+        'geodetic_longitude': '212.140',
+        'elevation': '197',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 16876
+    }
+]

--- a/geomagio/metadata/observatory/CMT.py
+++ b/geomagio/metadata/observatory/CMT.py
@@ -1,0 +1,17 @@
+"""CMT Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'College',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '64.874',
+        'geodetic_longitude': '212.140',
+        'elevation': '197',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 16876
+    }
+]

--- a/geomagio/metadata/observatory/DED.py
+++ b/geomagio/metadata/observatory/DED.py
@@ -1,0 +1,17 @@
+"""DED Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Deadhorse',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '70.355',
+        'geodetic_longitude': '211.207',
+        'elevation': '10',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 13200
+    }
+]

--- a/geomagio/metadata/observatory/DHT.py
+++ b/geomagio/metadata/observatory/DHT.py
@@ -1,0 +1,17 @@
+"""DHT Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Deadhorse Test',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '70.355',
+        'geodetic_longitude': '211.207',
+        'elevation': '10',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 13200
+    }
+]

--- a/geomagio/metadata/observatory/EUA.py
+++ b/geomagio/metadata/observatory/EUA.py
@@ -1,0 +1,17 @@
+"""EUA Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Eureka',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '55.300',
+        'geodetic_longitude': '282.300',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/FCC.py
+++ b/geomagio/metadata/observatory/FCC.py
@@ -1,0 +1,17 @@
+"""FCC Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Fort Churchill',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '58.800',
+        'geodetic_longitude': '265.900',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/FRD.py
+++ b/geomagio/metadata/observatory/FRD.py
@@ -1,0 +1,17 @@
+"""FRD Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Fredericksburg',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '38.205',
+        'geodetic_longitude': '282.627',
+        'elevation': '69',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 210942
+    }
+]

--- a/geomagio/metadata/observatory/FRN.py
+++ b/geomagio/metadata/observatory/FRN.py
@@ -1,0 +1,17 @@
+"""FRN Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Fresno',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '37.091',
+        'geodetic_longitude': '240.282',
+        'elevation': '331',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 9250
+    }
+]

--- a/geomagio/metadata/observatory/GUA.py
+++ b/geomagio/metadata/observatory/GUA.py
@@ -1,0 +1,17 @@
+"""GUA Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Guam',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '13.588',
+        'geodetic_longitude': '144.867',
+        'elevation': '140',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 1157
+    }
+]

--- a/geomagio/metadata/observatory/HAD.py
+++ b/geomagio/metadata/observatory/HAD.py
@@ -1,0 +1,17 @@
+"""HAD Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Hartland',
+        'agency_name': 'British Geological Survey (BGS)',
+        'geodetic_latitude': '51.000',
+        'geodetic_longitude': '355.500',
+        'elevation': '0',
+        'sensor_orientation': 'HDZF',
+        'reported': 'HDZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/HER.py
+++ b/geomagio/metadata/observatory/HER.py
@@ -1,0 +1,17 @@
+"""HER Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Hermanus',
+        'agency_name': 'National Research Foundation',
+        'geodetic_latitude': '-34.400',
+        'geodetic_longitude': '19.200',
+        'elevation': '0',
+        'sensor_orientation': 'HDZF',
+        'reported': 'HDZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/HON.py
+++ b/geomagio/metadata/observatory/HON.py
@@ -1,0 +1,17 @@
+"""HON Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Honolulu',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '21.316',
+        'geodetic_longitude': '202.000',
+        'elevation': '4',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 6920
+    }
+]

--- a/geomagio/metadata/observatory/IQA.py
+++ b/geomagio/metadata/observatory/IQA.py
@@ -1,0 +1,17 @@
+"""IQA Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Iqaluit',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '63.800',
+        'geodetic_longitude': '291.500',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/MEA.py
+++ b/geomagio/metadata/observatory/MEA.py
@@ -1,0 +1,17 @@
+"""MEA Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Meanook',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '54.600',
+        'geodetic_longitude': '246.700',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/NEW.py
+++ b/geomagio/metadata/observatory/NEW.py
@@ -1,0 +1,17 @@
+"""NEW Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Newport',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '48.265',
+        'geodetic_longitude': '242.878',
+        'elevation': '770',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 12133
+    }
+]

--- a/geomagio/metadata/observatory/OTT.py
+++ b/geomagio/metadata/observatory/OTT.py
@@ -1,0 +1,17 @@
+"""OTT Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Ottowa',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '45.400',
+        'geodetic_longitude': '284.500',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/RES.py
+++ b/geomagio/metadata/observatory/RES.py
@@ -1,0 +1,17 @@
+"""RES Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Resolute Bay',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '74.700',
+        'geodetic_longitude': '265.100',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/SHU.py
+++ b/geomagio/metadata/observatory/SHU.py
@@ -1,0 +1,17 @@
+"""SHU Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Shumagin',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '55.348',
+        'geodetic_longitude': '199.538',
+        'elevation': '80',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 13974
+    }
+]

--- a/geomagio/metadata/observatory/SIT.py
+++ b/geomagio/metadata/observatory/SIT.py
@@ -1,0 +1,17 @@
+"""SIT Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Sitka',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '57.058',
+        'geodetic_longitude': '224.675',
+        'elevation': '24',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 16523
+    }
+]

--- a/geomagio/metadata/observatory/SJG.py
+++ b/geomagio/metadata/observatory/SJG.py
@@ -1,0 +1,17 @@
+"""SJG Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'San Juan',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '18.113',
+        'geodetic_longitude': '293.849',
+        'elevation': '424',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 209800
+    }
+]

--- a/geomagio/metadata/observatory/SNK.py
+++ b/geomagio/metadata/observatory/SNK.py
@@ -1,0 +1,17 @@
+"""SNK Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Sanikiluaq',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '62.400',
+        'geodetic_longitude': '245.500',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/STJ.py
+++ b/geomagio/metadata/observatory/STJ.py
@@ -1,0 +1,17 @@
+"""STJ Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Saint John\'s',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '47.600',
+        'geodetic_longitude': '307.300',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/TST.py
+++ b/geomagio/metadata/observatory/TST.py
@@ -1,0 +1,17 @@
+"""TST Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Boulder Test',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '40.137',
+        'geodetic_longitude': '254.763',
+        'elevation': '1682',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 5527
+    }
+]

--- a/geomagio/metadata/observatory/TUC.py
+++ b/geomagio/metadata/observatory/TUC.py
@@ -1,0 +1,17 @@
+"""TUC Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Tucson',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '32.174',
+        'geodetic_longitude': '249.267',
+        'elevation': '946',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 7258
+    }
+]

--- a/geomagio/metadata/observatory/USGS.py
+++ b/geomagio/metadata/observatory/USGS.py
@@ -1,0 +1,17 @@
+"""USGS Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'USGS',
+        'agency_name': 'United States Geological Survey (USGS)',
+        'geodetic_latitude': '40.137',
+        'geodetic_longitude': '254.764',
+        'elevation': '1682',
+        'sensor_orientation': 'HDZF',
+        'sensor_sampling_rate': 0.01,
+        'declination_base': 0
+    }
+]

--- a/geomagio/metadata/observatory/VIC.py
+++ b/geomagio/metadata/observatory/VIC.py
@@ -1,0 +1,17 @@
+"""VIC Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Victoria',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '48.600',
+        'geodetic_longitude': '236.600',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/YKC.py
+++ b/geomagio/metadata/observatory/YKC.py
@@ -1,0 +1,17 @@
+"""YKC Observatory Metadata"""
+
+METADATA = [
+    {
+        'starttime': None,
+        'endtime': None,
+
+        'station_name': 'Yellow Knife',
+        'agency_name': 'Geological Survey of Canada (GSC)',
+        'geodetic_latitude': '62.400',
+        'geodetic_longitude': '245.500',
+        'elevation': '0',
+        'sensor_orientation': 'XYZF',
+        'reported': 'XYZF',
+        'sensor_sampling_rate': 0.01
+    }
+]

--- a/geomagio/metadata/observatory/__init__.py
+++ b/geomagio/metadata/observatory/__init__.py
@@ -1,0 +1,69 @@
+"""metadata.observatory module"""
+from __future__ import absolute_import, print_function
+
+import importlib
+import pkgutil
+import sys
+from obspy import UTCDateTime
+
+
+# module exports
+__all__ = [
+    'get_observatory'
+]
+
+
+# a dictionary of observatories, keyed by observatory ID
+OBSERVATORIES = {}
+
+
+# import all observatory metadata files
+prefix = __name__ + '.'
+__path__ = pkgutil.extend_path(__path__, __name__)
+for importer, modname, ispkg in pkgutil.walk_packages(
+        path=__path__,
+        prefix=prefix):
+    observatory = modname.replace(prefix, '')
+    module = importlib.import_module(modname)
+    if 'METADATA' not in dir(module):
+        print(modname + ' missing METADATA attribute', file=sys.stderr)
+    # add to OBSERVATORIES list
+    OBSERVATORIES[observatory] = module.METADATA
+    # export in __all__
+    __all__.append(observatory)
+
+
+def get_observatory(code, time=None, observatories=None):
+    """Get observatory metadata
+
+    Parameters
+    ----------
+    code : str
+        case sensitive observatory code
+    time : UTCDateTime
+        Default: now
+        time of metadata
+    observatories : dict
+        Default OBSERVATORIES
+        a custom dictionary of observatory metadata to scan.
+
+    Returns
+    -------
+    dict : dictionary of metadata, or
+    None : when no matching metadata found
+    """
+    observatories = observatories or OBSERVATORIES
+    if code not in observatories:
+        return None
+    time = time or UTCDateTime()
+    for epoch in observatories[code]:
+        starttime = epoch['starttime']
+        if starttime is not None:
+            starttime = UTCDateTime(starttime)
+        endtime = epoch['endtime']
+        if endtime is not None:
+            endtime = UTCDateTime(endtime)
+        if (starttime is None or starttime <= time) and \
+                (endtime is None or endtime > time):
+            return epoch
+    return None

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "license": "Public Domain",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^0.7.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-flake8": "^0.1.3",
-    "grunt-nose": "^0.4.0"
+    "grunt": "0.4.5",
+    "grunt-contrib-clean": "0.7.0",
+    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-flake8": "0.1.3",
+    "grunt-nose": "1.1.0"
   },
   "engines": {
     "node": ">=0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
         'geomagio.iaga2002',
         'geomagio.imfv122',
         'geomagio.imfv283',
+        'geomagio.metadata',
+        'geomagio.metadata.observatory',
         'geomagio.pcdcp',
         'geomagio.temperature',
         'geomagio.vbf'

--- a/test/metadata_test/observatory_test.py
+++ b/test/metadata_test/observatory_test.py
@@ -1,0 +1,75 @@
+"""Tests for the IMFV283 Parser class."""
+
+from nose.tools import assert_equals, assert_not_equals
+from obspy import UTCDateTime
+from geomagio.metadata import get_observatory
+
+
+TEST_OBSERVATORIES = {
+    'TEST': [
+        {
+            'starttime': '2017-01-01',
+            'endtime': None,
+
+            'foo': 'bar'
+        },
+        {
+            'starttime': '2016-01-01',
+            'endtime': '2016-12-01',
+
+            'foo': 'baz'
+        }
+    ]
+}
+
+
+def test_get_observatory_unknown():
+    """metadata_test.observatory_test.test_get_observatory_unknown()
+
+    Expect get_observatory to return None,
+    when code is not defined.
+    """
+    obs = get_observatory('OTHER', observatories=TEST_OBSERVATORIES)
+    assert_equals(obs, None)
+
+
+def test_get_observatory_latest():
+    """metadata_test.observatory_test.test_get_observatory_latest()
+
+    Expect get_observatory to return latest epoch,
+    when time not specified (and latest epoch doen't have endtime...)
+    """
+    obs = get_observatory('TEST', observatories=TEST_OBSERVATORIES)
+    assert_equals(obs['foo'], 'bar')
+
+
+def test_get_observatory_older():
+    """metadata_test.observatory_test.test_get_observatory_older()
+
+    Expect get_observatory to return specific epoch,
+    when time is specified
+    """
+    obs = get_observatory('TEST', time=UTCDateTime('2016-06-01'),
+            observatories=TEST_OBSERVATORIES)
+    assert_equals(obs['foo'], 'baz')
+
+
+def test_get_observatory_gap():
+    """metadata_test.observatory_test.test_get_observatory_gap()
+
+    Expect get_observatory to return None,
+    if specified time is in a metadata gap
+    """
+    obs = get_observatory('TEST', time=UTCDateTime('2016-12-02'),
+            observatories=TEST_OBSERVATORIES)
+    assert_equals(obs, None)
+
+
+def test_get_observatory_bou():
+    """metadata_test.observatory_test.test_get_observatory_gap()
+
+    Expect get_observatory to return None,
+    if specified time is in a metadata gap
+    """
+    obs = get_observatory('BOU')
+    assert_not_equals(obs, None)


### PR DESCRIPTION
This is not yet fully integrated, and is a work in progress.  Creating pull request to get comments on the approach before I make any further changes.

Right now these files deal mainly with observatory level information, but with a little more structure could potentially also be used for SqDist and other configuration parameters; or those could be stored in a parallel metadata package.

I know we have ongoing discussions over storing metadata in a database or similar, but I would like to continue supporting offline processing using these or similar files.  If we integrate with another system, we could potentially add a script to download/update files like this.
