### PR TITLE
Add channels to edge factory

### DIFF
--- a/geomagio/edge/EdgeFactory.py
+++ b/geomagio/edge/EdgeFactory.py
@@ -385,6 +385,18 @@ class EdgeFactory(TimeseriesFactory):
             edge_channel = edge_interval_code + 'VX'
         elif channel == 'Y':
             edge_channel = edge_interval_code + 'VY'
+        elif channel == 'E-E':
+            edge_channel = edge_interval_code + 'QE'
+        elif channel == 'E-N':
+            edge_channel = edge_interval_code + 'QN'
+        elif channel == 'DIST':
+            edge_channel = edge_interval_code + 'DT'
+        elif channel == 'DST':
+            edge_channel = edge_interval_code + 'GD'
+        elif channel == 'SQ':
+            edge_channel = edge_interval_code + 'SQ'
+        elif channel == 'SV':
+            edge_channel = edge_interval_code + 'SV'
         else:
             edge_channel = channel
         return edge_channel

--- a/geomagio/iaga2002/IAGA2002Writer.py
+++ b/geomagio/iaga2002/IAGA2002Writer.py
@@ -194,7 +194,7 @@ class IAGA2002Writer(object):
         buf = ['DATE       TIME         DOY  ']
         for channel in channels:
             channel_len = len(channel)
-            if channel_len < 1 or channel_len > 3:
+            if channel_len < 1 or channel_len > 4:
                 raise TimeseriesFactoryException(
                         'channel "{}" is not 1 character'.format(channel))
             buf.append('   {:<7s}'.format(iaga_code + channel))

--- a/test/edge_test/EdgeFactory_test.py
+++ b/test/edge_test/EdgeFactory_test.py
@@ -34,8 +34,14 @@ def test__get_edge_channel():
             'MSF')
     assert_equals(EdgeFactory()._get_edge_channel('', 'H', '', 'minute'),
             'MVH')
-    assert_equals(EdgeFactory()._get_edge_channel('', 'Z', '', 'minute'),
-            'MVZ')
+    assert_equals(EdgeFactory()._get_edge_channel('', 'DIST', '', 'minute'),
+            'MDT')
+    assert_equals(EdgeFactory()._get_edge_channel('', 'DST', '', 'minute'),
+            'MGD')
+    assert_equals(EdgeFactory()._get_edge_channel('', 'E-E', '', 'minute'),
+            'MQE')
+    assert_equals(EdgeFactory()._get_edge_channel('', 'E-N', '', 'minute'),
+            'MQN')
 
 
 def test__get_edge_location():


### PR DESCRIPTION
Added channel mapping for 'E-N', 'E-E',  'SQ', 'SV', 'DIST', and 'DST' similar to: https://github.com/usgs/geomag-edge-ws/blob/master/src/lib/classes/GeomagWebService.class.php#L214. Also updated the maximum channel length in IAGA2002Writer to 4, to accommodate for 'DIST' as a channel. Addresses issue #166.