### PR TITLE
WIP: Initial get_sncl/parse_sncl implementation

### DIFF
--- a/geomagio/edge/sncl.py
+++ b/geomagio/edge/sncl.py
@@ -9,8 +9,8 @@ Location
 # components that map directly to channel suffixes
 CHANNEL_FROM_COMPONENT = {
     # e-field
-    'E-E':  'QX',
-    'E-N':  'QY',
+    'E-E':  'QY',
+    'E-N':  'QX',
     'E-U':  'QU',
     'E-V':  'QV',
     # derived indicies

--- a/geomagio/edge/sncl.py
+++ b/geomagio/edge/sncl.py
@@ -6,6 +6,7 @@ Channel
 Location
 """
 
+# components that map directly to channel suffixes
 CHANNEL_FROM_COMPONENT = {
     # e-field
     'E-E':  'QX',
@@ -18,6 +19,7 @@ CHANNEL_FROM_COMPONENT = {
     'DST':  'X4',
     'K':    'XK'
 }
+# reverse lookup of component from channel
 COMPONENT_FROM_CHANNEL = dict((v,k) for (k,v) in CHANNEL_FROM_COMPONENT.iteritems())
 
 
@@ -29,9 +31,46 @@ def get_scnl(observatory,
         component=None,
         channel=None,
         data_type='variation',
-        location=None,
         interval='second',
+        location=None,
         network='NT'):
+    """Generate a SNCL code from data attributes.
+
+    Parameters
+    ----------
+    observatory : str
+        observatory code.
+    component : str
+        geomag component name.
+    channel : str
+        default None.
+        use a specific channel code, instead of generating.
+    data_type : str
+        default 'variation'
+        'variation', 'adjusted', 'quasi-definitive', or 'definitive'.
+    interval: str|float
+        default 'second'
+        'tenhertz', 'second', 'minute', 'hour', 'day',
+        or equivalent interval in seconds
+    location : str
+        default None
+        use a specific location code, instead of generating.
+    network : str
+        default 'NT'
+        network `observatory` is a part of.
+
+    Raises
+    ------
+    SNCLException : when unable to generate a SNCL
+
+    Returns
+    -------
+    dict : dictionary containing the following keys
+        'station'  : observatory code
+        'network'  : network code
+        'channel'  : channel code
+        'location' : location code
+    """
     # use explicit channel/location if specified
     channel = channel or __get_channel(component, interval)
     location = location or __get_location(component, data_type)
@@ -43,6 +82,30 @@ def get_scnl(observatory,
     }
 
 def parse_sncl(sncl):
+    """Parse a SNCL code into data attributes.
+
+    Parameters
+    ----------
+    sncl : dict
+        dictionary object with the following keys
+            'station'  : observatory code
+            'network'  : network code
+            'channel'  : channel code
+            'location' : location code
+
+    Raises
+    ------
+    SNCLException : when unable to parse a SNCL
+
+    Returns
+    -------
+    dict : dictionary containing the following keys
+        'observatory' : observatory code
+        'network'     : network code
+        'component'   : geomag component name
+        'data_type'   : geomag data type (e.g. 'variation')
+        'interval'    : data interval in seconds (e.g. 1)
+    """
     network = sncl['network']
     station = sncl['station']
     channel = sncl['channel']

--- a/geomagio/edge/sncl.py
+++ b/geomagio/edge/sncl.py
@@ -129,7 +129,7 @@ def __get_channel(component, interval):
     return channel_start + channel_end
 
 def __get_channel_start(interval):
-    if interval == '10hertz' or interval == 0.1:
+    if interval == 'tenhertz' or interval == 0.1:
         return 'B'
     if interval == 'second' or interval == 1:
         return 'L'

--- a/geomagio/edge/sncl.py
+++ b/geomagio/edge/sncl.py
@@ -9,18 +9,19 @@ Location
 # components that map directly to channel suffixes
 CHANNEL_FROM_COMPONENT = {
     # e-field
-    'E-E':  'QY',
-    'E-N':  'QX',
-    'E-U':  'QU',
-    'E-V':  'QV',
+    'E-E': 'QY',
+    'E-N': 'QX',
+    'E-U': 'QU',
+    'E-V': 'QV',
     # derived indicies
-    'AE':   'XA',
+    'AE': 'XA',
     'DST3': 'X3',
-    'DST':  'X4',
-    'K':    'XK'
+    'DST': 'X4',
+    'K': 'XK'
 }
 # reverse lookup of component from channel
-COMPONENT_FROM_CHANNEL = dict((v,k) for (k,v) in CHANNEL_FROM_COMPONENT.iteritems())
+COMPONENT_FROM_CHANNEL = dict(
+        (v, k) for (k, v) in CHANNEL_FROM_COMPONENT.iteritems())
 
 
 class SNCLException(Exception):
@@ -81,6 +82,7 @@ def get_scnl(observatory,
         'location': location,
     }
 
+
 def parse_sncl(sncl):
     """Parse a SNCL code into data attributes.
 
@@ -128,6 +130,7 @@ def __get_channel(component, interval):
         channel_end = __get_channel_end(component)
     return channel_start + channel_end
 
+
 def __get_channel_start(interval):
     if interval == 'tenhertz' or interval == 0.1:
         return 'B'
@@ -140,6 +143,7 @@ def __get_channel_start(interval):
     if interval == 'day' or interval == 86400:
         return 'P'
     raise SNCLException('Unexpected interval {}'.format(interval))
+
 
 def __get_channel_end(component):
     # default to engineering units
@@ -165,6 +169,7 @@ def __get_location(component, data_type):
     location_end = __get_location_end(component)
     return location_start + location_end
 
+
 def __get_location_start(data_type):
     if data_type == 'variation':
         return 'R'
@@ -175,6 +180,7 @@ def __get_location_start(data_type):
     elif data_type == 'definitive':
         return 'D'
     raise SNCLException('Unexpected data type {}'.format(data_type))
+
 
 def __get_location_end(component):
     if component.endswith('-Sat'):
@@ -207,6 +213,7 @@ def __parse_component(channel, location):
         raise SNCLException('Unexpected channel middle {}'.format(channel))
     return component + component_end
 
+
 def __parse_component_end(location):
     location_end = location[1]
     if location_end == '0':
@@ -221,6 +228,7 @@ def __parse_component_end(location):
         return '-SV'
     raise SNCLException('Unexpected location end {}'.format(location_end))
 
+
 def __parse_data_type(location):
     location_start = location[0]
     if location_start == 'R':
@@ -232,6 +240,7 @@ def __parse_data_type(location):
     if location_start == 'D':
         return 'definitive'
     raise SNCLException('Unexpected location start {}'.format(location_start))
+
 
 def __parse_interval(channel):
     channel_start = channel[0]

--- a/geomagio/edge/sncl.py
+++ b/geomagio/edge/sncl.py
@@ -1,0 +1,185 @@
+"""SNCL utilities.
+
+Station
+Network
+Channel
+Location
+"""
+
+CHANNEL_FROM_COMPONENT = {
+    # e-field
+    'E-E':  'QX',
+    'E-N':  'QY',
+    'E-U':  'QU',
+    'E-V':  'QV',
+    # derived indicies
+    'AE':   'XA',
+    'DST3': 'X3',
+    'DST':  'X4',
+    'K':    'XK'
+}
+COMPONENT_FROM_CHANNEL = dict((v,k) for (k,v) in CHANNEL_FROM_COMPONENT.iteritems())
+
+
+class SNCLException(Exception):
+    pass
+
+
+def get_scnl(observatory,
+        component=None,
+        channel=None,
+        data_type='variation',
+        location=None,
+        interval='second',
+        network='NT'):
+    # use explicit channel/location if specified
+    channel = channel or __get_channel(component, interval)
+    location = location or __get_location(component, data_type)
+    return {
+        'station': observatory,
+        'network': network,
+        'channel': channel,
+        'location': location,
+    }
+
+def parse_sncl(sncl):
+    network = sncl['network']
+    station = sncl['station']
+    channel = sncl['channel']
+    location = sncl['location']
+    return {
+        'observatory': station,
+        'network': network,
+        'component': __parse_component(channel, location),
+        'data_type': __parse_data_type(location),
+        'interval': __parse_interval(channel),
+    }
+
+
+def __get_channel(component, interval):
+    channel_start = __get_channel_start(interval)
+    # check for direct component mappings
+    if component in CHANNEL_FROM_COMPONENT:
+        channel_end = CHANNEL_FROM_COMPONENT[component]
+    else:
+        channel_end = __get_channel_end(component)
+    return channel_start + channel_end
+    
+def __get_channel_start(interval):
+    if interval == '10hertz' or interval == 0.1:
+        return 'B'
+    if interval == 'second' or interval == 1:
+        return 'L'
+    if interval == 'minute' or interval == 60:
+        return 'U'
+    if interval == 'hour' or interval == 3600:
+        return 'R'
+    if interval == 'day' or interval == 86400:
+        return 'P'
+    raise SNCLException('Unexpected interval {}'.format(interval))
+
+def __get_channel_end(component):
+    # default to engineering units
+    channel_middle = 'F'
+    # check for suffix that may override
+    component_parts = component.split('-')
+    channel_end = component_parts[0]
+    if len(component_parts) > 1:
+        component_suffix = component_parts[1]
+        if component_suffix == '-Bin':
+            channel_middle = 'Y'
+        elif component_suffix == '-Temp':
+            channel_middle = 'K'
+        elif component_suffix == '-Volt':
+            channel_middle = 'E'
+        else:
+            raise SNCLException('Unexpected component {}'.format(component))
+    return channel_middle + channel_end
+
+
+def __get_location(component, data_type):
+    location_start = __get_location_start(data_type)
+    location_end = __get_location_end(component)
+    return location_start + location_end
+
+def __get_location_start(data_type):
+    if data_type == 'variation':
+        return 'R'
+    elif data_type == 'adjusted':
+        return 'A'
+    elif data_type == 'quasi-definitive':
+        return 'Q'
+    elif data_type == 'definitive':
+        return 'D'
+    raise SNCLException('Unexpected data type {}'.format(data_type))
+
+def __get_location_end(component):
+    if component.endswith('-Sat'):
+        return '1'
+    if component.endswith('-Dist'):
+        return 'D'
+    if component.endswith('-SQ'):
+        return 'Q'
+    if component.endswith('-SV'):
+        return 'V'
+    return '0'
+
+
+def __parse_component(channel, location):
+    channel_end = channel[1:]
+    if channel_end in COMPONENT_FROM_CHANNEL:
+        return COMPONENT_FROM_CHANNEL[channel_end]
+    channel_middle = channel[1]
+    component = channel[2]
+    component_end = ''
+    if channel_middle == 'E':
+        component_end = '-Volt'
+    elif channel_middle == 'K':
+        component_end = '-Temp'
+    elif channel_middle == 'Y':
+        component_end = '-Bin'
+    elif channel_middle == 'F':
+        component_end = __parse_component_end(location)
+    else:
+        raise SNCLException('Unexpected channel middle {}'.format(channel))
+    return component + component_end
+
+def __parse_component_end(location):
+    location_end = location[1]
+    if location_end == '0':
+        return ''
+    if location_end == '1':
+        return '-Sat'
+    if location_end == 'D':
+        return '-Dist'
+    if location_end == 'Q':
+        return '-SQ'
+    if location_end == 'V':
+        return '-SV'
+    raise SNCLException('Unexpected location end {}'.format(location_end))
+
+def __parse_data_type(location):
+    location_start = location[0]
+    if location_start == 'R':
+        return 'variation'
+    if location_start == 'A':
+        return 'adjusted'
+    if location_start == 'Q':
+        return 'quasi-definitive'
+    if location_start == 'D':
+        return 'definitive'
+    raise SNCLException('Unexpected location start {}'.format(location_start))
+
+def __parse_interval(channel):
+    channel_start = channel[0]
+    if channel_start == 'B':
+        return 0.1
+    if channel_start == 'L':
+        return 1
+    if channel_start == 'U':
+        return 60
+    if channel_start == 'R':
+        return 3600
+    if channel_start == 'P':
+        return 86400
+    raise SNCLException('Unexpected channel {}'.format(channel))

--- a/geomagio/edge/sncl.py
+++ b/geomagio/edge/sncl.py
@@ -64,7 +64,7 @@ def __get_channel(component, interval):
     else:
         channel_end = __get_channel_end(component)
     return channel_start + channel_end
-    
+
 def __get_channel_start(interval):
     if interval == '10hertz' or interval == 0.1:
         return 'B'


### PR DESCRIPTION
Work in progress, please do not merge yet, looking for feedback on the implementation and whether you see any problems that may come up moving forward.  We could potentially implement a parallel legacy_sncl module...


Initial attempt to provide translation between proposed SNCL mapping ( https://github.com/INTERMAGNET/miniseed-sncl/blob/master/SNCL.md ) and component/interval/data_type values

- Standardizes component, data_type, and interval naming:

```
data_type : (variation|adjusted|quasi-definitive|definitive)
```
are there other data types that should be included?

```
interval : (tenhertz|second|minute|hour|day) or numeric seconds equivalent
```
are there other intervals that should be included?

```
component : (AE|DST3|DST|E-E|E-N|E-U|E-V|K) | (component_name[-component_suffix])
component_name : (D|F|G|H|U|V|W|X|Y|Z)
component_suffix : (Bin|Dist|Sat|SQ|SV|Temp|Volt)
```
the components map either directly to channel codes, or are a combination of a component name and suffix based on a decomposition of that component.

are there other components that should be included?

For example `U-Sat` would reference the observatory H component satellite feed (or R1 edge location).  `U-Bin` and `U-Volt` would be acquired, and combined to calculate `U` which is the engineering unit value of the observatory H component...

