### PR TITLE
Required Channels Implementation for XYZ Algorithm

### DIFF
--- a/geomagio/Controller.py
+++ b/geomagio/Controller.py
@@ -246,7 +246,7 @@ class Controller(object):
                     starttime=output_gap[0],
                     endtime=output_gap[1],
                     stream=input_timeseries,
-                    channels = algorithm.get_required_channels() or \
+                    channels=algorithm.get_required_channels() or
                         input_channels):
                 continue
             # check for fillable gap at start

--- a/geomagio/Controller.py
+++ b/geomagio/Controller.py
@@ -245,9 +245,7 @@ class Controller(object):
             if not algorithm.can_produce_data(
                     starttime=output_gap[0],
                     endtime=output_gap[1],
-                    stream=input_timeseries,
-                    channels=algorithm.get_required_channels() or
-                        input_channels):
+                    stream=input_timeseries):
                 continue
             # check for fillable gap at start
             if output_gap[0] == options.starttime:

--- a/geomagio/Controller.py
+++ b/geomagio/Controller.py
@@ -245,7 +245,9 @@ class Controller(object):
             if not algorithm.can_produce_data(
                     starttime=output_gap[0],
                     endtime=output_gap[1],
-                    stream=input_timeseries):
+                    stream=input_timeseries,
+                    channels = algorithm.get_required_channels() or \
+                        input_channels):
                 continue
             # check for fillable gap at start
             if output_gap[0] == options.starttime:

--- a/geomagio/StreamConverter.py
+++ b/geomagio/StreamConverter.py
@@ -35,8 +35,7 @@ def get_geo_from_mag(mag):
     (geo_x, geo_y) = ChannelConverter.get_geo_from_mag(mag_h, mag_d)
     return obspy.core.Stream((
         __get_trace('X', h.stats, geo_x),
-        __get_trace('Y', d.stats, geo_y),
-        )) + z + f
+        __get_trace('Y', d.stats, geo_y))) + z + f
 
 
 def get_geo_from_obs(obs):
@@ -123,8 +122,7 @@ def get_mag_from_geo(geo):
     (mag_h, mag_d) = ChannelConverter.get_mag_from_geo(geo_x, geo_y)
     return obspy.core.Stream((
             __get_trace('H', x.stats, mag_h),
-            __get_trace('D', y.stats, mag_d),
-            )) + z + f
+            __get_trace('D', y.stats, mag_d))) + z + f
 
 
 def get_mag_from_obs(obs):
@@ -151,8 +149,7 @@ def get_mag_from_obs(obs):
     (mag_h, mag_d) = ChannelConverter.get_mag_from_obs(obs_h, obs_e, d0)
     return obspy.core.Stream((
             __get_trace('H', h.stats, mag_h),
-            __get_trace('D', e.stats, mag_d),
-            )) + z + f
+            __get_trace('D', e.stats, mag_d))) + z + f
 
 
 def get_obs_from_geo(geo, include_d=False):
@@ -200,8 +197,7 @@ def get_obs_from_mag(mag, include_d=False):
 
     traces = (
         __get_trace('H', h.stats, obs_h),
-        __get_trace('E', d.stats, obs_e),
-        )
+        __get_trace('E', d.stats, obs_e))
     if include_d:
         obs_d = ChannelConverter.get_obs_d_from_obs(obs_h, obs_e)
         traces = traces + (__get_trace('D', d.stats, obs_d),)

--- a/geomagio/StreamConverter.py
+++ b/geomagio/StreamConverter.py
@@ -28,15 +28,15 @@ def get_geo_from_mag(mag):
     """
     h = mag.select(channel='H')[0]
     d = mag.select(channel='D')[0]
-    z = mag.select(channel='Z')[0]
-    f = mag.select(channel='F')[0]
+    z = mag.select(channel='Z')
+    f = mag.select(channel='F')
     mag_h = h.data
     mag_d = d.data
     (geo_x, geo_y) = ChannelConverter.get_geo_from_mag(mag_h, mag_d)
     return obspy.core.Stream((
         __get_trace('X', h.stats, geo_x),
         __get_trace('Y', d.stats, geo_y),
-        z, f))
+        )) + z + f
 
 
 def get_geo_from_obs(obs):
@@ -116,15 +116,15 @@ def get_mag_from_geo(geo):
     """
     x = geo.select(channel='X')[0]
     y = geo.select(channel='Y')[0]
-    z = geo.select(channel='Z')[0]
-    f = geo.select(channel='F')[0]
+    z = geo.select(channel='Z')
+    f = geo.select(channel='F')
     geo_x = x.data
     geo_y = y.data
     (mag_h, mag_d) = ChannelConverter.get_mag_from_geo(geo_x, geo_y)
     return obspy.core.Stream((
             __get_trace('H', x.stats, mag_h),
             __get_trace('D', y.stats, mag_d),
-            z, f))
+            )) + z + f
 
 
 def get_mag_from_obs(obs):
@@ -142,8 +142,8 @@ def get_mag_from_obs(obs):
     """
     h = obs.select(channel='H')[0]
     e = __get_obs_e_from_obs(obs)
-    z = obs.select(channel='Z')[0]
-    f = obs.select(channel='F')[0]
+    z = obs.select(channel='Z')
+    f = obs.select(channel='F')
     obs_h = h.data
     obs_e = e.data
     d0 = ChannelConverter.get_radians_from_minutes(
@@ -152,7 +152,7 @@ def get_mag_from_obs(obs):
     return obspy.core.Stream((
             __get_trace('H', h.stats, mag_h),
             __get_trace('D', e.stats, mag_d),
-            z, f))
+            )) + z + f
 
 
 def get_obs_from_geo(geo, include_d=False):
@@ -189,8 +189,9 @@ def get_obs_from_mag(mag, include_d=False):
     """
     h = mag.select(channel='H')[0]
     d = mag.select(channel='D')[0]
-    z = mag.select(channel='Z')[0]
-    f = mag.select(channel='F')[0]
+    z = mag.select(channel='Z')
+    f = mag.select(channel='F')
+
     mag_h = h.data
     mag_d = d.data
     d0 = ChannelConverter.get_radians_from_minutes(
@@ -200,11 +201,11 @@ def get_obs_from_mag(mag, include_d=False):
     traces = (
         __get_trace('H', h.stats, obs_h),
         __get_trace('E', d.stats, obs_e),
-        z, f)
+        )
     if include_d:
         obs_d = ChannelConverter.get_obs_d_from_obs(obs_h, obs_e)
         traces = traces + (__get_trace('D', d.stats, obs_d),)
-    return obspy.core.Stream(traces)
+    return obspy.core.Stream(traces) + z + f
 
 
 def get_obs_from_obs(obs, include_e=False, include_d=False):
@@ -225,16 +226,16 @@ def get_obs_from_obs(obs, include_e=False, include_d=False):
         new stream object containing observatory components H, D, E, Z, and F
     """
     h = obs.select(channel='H')[0]
-    z = obs.select(channel='Z')[0]
-    f = obs.select(channel='F')[0]
-    traces = (h, z, f)
+    z = obs.select(channel='Z')
+    f = obs.select(channel='F')
+    traces = (h, )
     if include_d:
         d = __get_obs_d_from_obs(obs)
         traces = traces + (d, )
     if include_e:
         e = __get_obs_e_from_obs(obs)
         traces = traces + (e, )
-    return obspy.core.Stream(traces)
+    return obspy.core.Stream(traces) + z + f
 
 
 def __get_trace(channel, stats, data):

--- a/geomagio/algorithm/Algorithm.py
+++ b/geomagio/algorithm/Algorithm.py
@@ -87,7 +87,7 @@ class Algorithm(object):
         """
         return (start, end)
 
-    def can_produce_data(self, starttime, endtime, stream, channels = None):
+    def can_produce_data(self, starttime, endtime, stream, channels=None):
         """Can Product data
 
         Parameters
@@ -100,7 +100,7 @@ class Algorithm(object):
             The input stream we want to make certain has data for the algorithm
         """
         input_gaps = TimeseriesUtility.get_merged_gaps(
-                TimeseriesUtility.get_stream_gaps(stream,channels))
+                TimeseriesUtility.get_stream_gaps(stream, channels))
         for input_gap in input_gaps:
             # Check for gaps that include the entire range
             if (starttime >= input_gap[0] and

--- a/geomagio/algorithm/Algorithm.py
+++ b/geomagio/algorithm/Algorithm.py
@@ -87,7 +87,7 @@ class Algorithm(object):
         """
         return (start, end)
 
-    def can_produce_data(self, starttime, endtime, stream):
+    def can_produce_data(self, starttime, endtime, stream, channels = None):
         """Can Product data
 
         Parameters
@@ -100,7 +100,7 @@ class Algorithm(object):
             The input stream we want to make certain has data for the algorithm
         """
         input_gaps = TimeseriesUtility.get_merged_gaps(
-                TimeseriesUtility.get_stream_gaps(stream))
+                TimeseriesUtility.get_stream_gaps(stream,channels))
         for input_gap in input_gaps:
             # Check for gaps that include the entire range
             if (starttime >= input_gap[0] and

--- a/geomagio/algorithm/Algorithm.py
+++ b/geomagio/algorithm/Algorithm.py
@@ -87,7 +87,7 @@ class Algorithm(object):
         """
         return (start, end)
 
-    def can_produce_data(self, starttime, endtime, stream, channels=None):
+    def can_produce_data(self, starttime, endtime, stream):
         """Can Product data
 
         Parameters
@@ -100,7 +100,9 @@ class Algorithm(object):
             The input stream we want to make certain has data for the algorithm
         """
         input_gaps = TimeseriesUtility.get_merged_gaps(
-                TimeseriesUtility.get_stream_gaps(stream, channels))
+                TimeseriesUtility.get_stream_gaps(
+                    stream=stream,
+                    channels=self.get_required_channels()))
         for input_gap in input_gaps:
             # Check for gaps that include the entire range
             if (starttime >= input_gap[0] and

--- a/geomagio/algorithm/Algorithm.py
+++ b/geomagio/algorithm/Algorithm.py
@@ -46,6 +46,16 @@ class Algorithm(object):
         """
         return self._inchannels
 
+    def get_required_channels(self):
+        """Get only required channels
+
+        Returns
+        -------
+        array_like
+            list of channels essential to the algorithm
+        """
+        return self._inchannels
+
     def get_output_channels(self):
         """Get output channels
 

--- a/geomagio/algorithm/XYZAlgorithm.py
+++ b/geomagio/algorithm/XYZAlgorithm.py
@@ -110,7 +110,6 @@ class XYZAlgorithm(Algorithm):
             elif informat == 'obs' or informat == 'obsd':
                 out_stream = StreamConverter.get_obs_from_obs(timeseries,
                         include_d=True)
-
         return out_stream
 
     @classmethod

--- a/geomagio/algorithm/XYZAlgorithm.py
+++ b/geomagio/algorithm/XYZAlgorithm.py
@@ -142,13 +142,13 @@ class XYZAlgorithm(Algorithm):
         self._outformat = arguments.xyz_to
         self._inchannels = arguments.inchannels or \
                             CHANNELS[self._informat]
-        # outchannels set according to specified outchannels or inchannel designation
+        # Set outchannels to outchannel argument or inchannel designation
         # if the inchannels do not have 'Z' or 'F' neither will the outchannel
         if arguments.outchannels:
             self._outchannels = arguments.outchannels
         else:
             self._outchannels = CHANNELS[self._outformat]
-            if not 'Z' in self._inchannels:
+            if 'Z' not in self._inchannels:
                 del self._outchannels[self._outchannels.index('Z')]
-            if not 'F' in self._inchannels:
+            if 'F' not in self._inchannels:
                 del self._outchannels[self._outchannels.index('F')]

--- a/geomagio/algorithm/XYZAlgorithm.py
+++ b/geomagio/algorithm/XYZAlgorithm.py
@@ -140,15 +140,5 @@ class XYZAlgorithm(Algorithm):
         """
         self._informat = arguments.xyz_from
         self._outformat = arguments.xyz_to
-        self._inchannels = arguments.inchannels or \
-                            CHANNELS[self._informat]
-        # Set outchannels to outchannel argument or inchannel designation
-        # if the inchannels do not have 'Z' or 'F' neither will the outchannel
-        if arguments.outchannels:
-            self._outchannels = arguments.outchannels
-        else:
-            self._outchannels = CHANNELS[self._outformat]
-            if 'Z' not in self._inchannels:
-                del self._outchannels[self._outchannels.index('Z')]
-            if 'F' not in self._inchannels:
-                del self._outchannels[self._outchannels.index('F')]
+        self._inchannels = CHANNELS[self._informat]
+        self._outchannels = CHANNELS[self._outformat]

--- a/geomagio/algorithm/XYZAlgorithm.py
+++ b/geomagio/algorithm/XYZAlgorithm.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 from .Algorithm import Algorithm
 from .AlgorithmException import AlgorithmException
 from .. import StreamConverter
-import numpy as np
 
 # List of channels by geomagnetic observatory orientation.
 # geo represents a geographic north/south orientation

--- a/test/algorithm_test/XYZAlgorithm_test.py
+++ b/test/algorithm_test/XYZAlgorithm_test.py
@@ -35,21 +35,22 @@ def test_xyzalgorithm_channels():
     assert_equals(algorithm.get_input_channels(), inchannels)
     assert_equals(algorithm.get_output_channels(), outchannels)
 
+
 def test_xyzalgorithm_limited_channels():
     """XYZAlgorithm_test.test_xyzalgorithm_limited_channels()
 
     confirms that only the required channels are necessary for processing
     ie. 'H' and 'E' are only needed to get 'X' and 'Y' without 'Z' or 'F'
     """
-    algorithm = XYZAlgorithm('obs','mag')
+    algorithm = XYZAlgorithm('obs', 'mag')
     count = 5
-    outchannels = ['D']
     timeseries = Stream()
-    timeseries += __create_trace('H',[2]*count)
-    timeseries += __create_trace('E',[3]*count)
+    timeseries += __create_trace('H', [2] * count)
+    timeseries += __create_trace('E', [3] * count)
     outstream = algorithm.process(timeseries)
-    assert_equals(len(outstream.select(channel = 'D')[0].data),count)
-    assert_not_equal(outstream.select(channel='D')[0].data.any(),np.NaN)
+    assert_equals(len(outstream.select(channel='D')[0].data), count)
+    assert_not_equal(outstream.select(channel='D')[0].data.any(), np.NaN)
+
 
 def test_xyzalgorithm_uneccesary_channel_empty():
     """XYZAlgorithm_test.test_xyzalgorithm_uneccesary_channel_gaps()
@@ -59,14 +60,16 @@ def test_xyzalgorithm_uneccesary_channel_empty():
     or and empty 'F' channel. This also makes sure the 'Z' and 'F' channels
     are passed without any modification.
     """
-    algorithm = XYZAlgorithm('obs','mag')
+    algorithm = XYZAlgorithm('obs', 'mag')
     timeseries = Stream()
     timeseries += __create_trace('H', [1, 1])
     timeseries += __create_trace('E', [1, 1])
     timeseries += __create_trace('Z', [1, np.NaN])
-    timeseries += __create_trace('F', [np.NaN,np.NaN])
+    timeseries += __create_trace('F', [np.NaN, np.NaN])
     outstream = algorithm.process(timeseries)
-    assert_equals(outstream.select(channel = 'Z')[0].data.all(),timeseries.select(channel='Z')[0].data.all())
-    assert_equals(outstream.select(channel = 'F')[0].data.all(),timeseries.select(channel='F')[0].data.all())
-    assert_equals(len(outstream.select(channel='D')[0].data),2)
-    assert_not_equal(outstream.select(channel = 'D')[0].data.any(),np.NaN)
+    assert_equals(outstream.select(channel='Z')[0].data.all(),
+        timeseries.select(channel='Z')[0].data.all())
+    assert_equals(outstream.select(channel='F')[0].data.all(),
+        timeseries.select(channel='F')[0].data.all())
+    assert_equals(len(outstream.select(channel='D')[0].data), 2)
+    assert_not_equal(outstream.select(channel='D')[0].data.any(), np.NaN)


### PR DESCRIPTION
Generally only two channels are required for converting in the XYZ Algorithm as Z and F stay the same. While Barrow's F channel was down the algorithm would fail saying that the F channel was necessary when it could be done without the F channel. This update implements a get_required_channels() function in the Algorithm so that get_stream_gaps() and can_produce_data() will only check for the required channels. Changes in the StreamConverter updated how the Z and F channels were being used so that empty or non-existent Z and F channels could be passed without causing the algorithm to fail.