### PR TITLE
Clean timeseries: fixes issues #210 and #211

### DIFF
--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -195,36 +195,17 @@ def merge_streams(*streams):
         stream with contiguous traces merged, and gaps filled with numpy.nan
     """
     merged = obspy.core.Stream()
-    # masked_trace = None
-
     # add unmasked, split traces to be merged
     for stream in streams:
         merged += mask_stream(stream)
-
-    # if trace is completely masked separate out to be added back in later
-    # for trace in merged:
-    #     if trace.data.mask.all():
-    #         if not masked_trace:
-    #             masked_trace = trace
-    #         else:
-    #             masked_trace += trace
-
     # split traces that contain gaps
     merged = merged.split()
-
     # merge data
     merged.merge(
             # 1 = do not interpolate
             interpolation_samples=1,
             # 1 = when there is overlap, use data from trace with last endtime
             method=1)
-
-    # trim masked trace to the same size as other traces and add back to merged stream
-    # if masked_trace:
-    #     masked_trace.trim(merged[0].stats.starttime,merged[0].stats.endtime)
-    #     merged += masked_trace
-
-
     # convert back to NaN filled array
     merged = unmask_stream(merged)
     return merged

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -195,17 +195,36 @@ def merge_streams(*streams):
         stream with contiguous traces merged, and gaps filled with numpy.nan
     """
     merged = obspy.core.Stream()
+    # masked_trace = None
+
     # add unmasked, split traces to be merged
     for stream in streams:
         merged += mask_stream(stream)
+
+    # if trace is completely masked separate out to be added back in later
+    # for trace in merged:
+    #     if trace.data.mask.all():
+    #         if not masked_trace:
+    #             masked_trace = trace
+    #         else:
+    #             masked_trace += trace
+
     # split traces that contain gaps
     merged = merged.split()
+
     # merge data
     merged.merge(
             # 1 = do not interpolate
             interpolation_samples=1,
             # 1 = when there is overlap, use data from trace with last endtime
             method=1)
+
+    # trim masked trace to the same size as other traces and add back to merged stream
+    # if masked_trace:
+    #     masked_trace.trim(merged[0].stats.starttime,merged[0].stats.endtime)
+    #     merged += masked_trace
+
+
     # convert back to NaN filled array
     merged = unmask_stream(merged)
     return merged

--- a/test/edge_test/EdgeFactory_test.py
+++ b/test/edge_test/EdgeFactory_test.py
@@ -126,7 +126,6 @@ def test_create_missing_channel():
     trace1 = _create_trace([1, 1, 1, 1, 1], 'H', UTCDateTime("2018-01-01"))
     trace2 = _create_trace([2, 2], 'E', UTCDateTime("2018-01-01"))
     observatory = 'Test'
-    type = 'variation'
     interval = 'minute'
     network = 'NT'
     location = 'R0'
@@ -135,7 +134,7 @@ def test_create_missing_channel():
         endtime=trace1.stats.endtime,
         observatory=observatory,
         channel='F',
-        type=type,
+        type='variation',
         interval=interval,
         network=network,
         station=trace1.stats.station,
@@ -144,7 +143,7 @@ def test_create_missing_channel():
     # For continuity set stats to be same for all traces
     for trace in timeseries:
         trace.stats.observatory = observatory
-        trace.stats.type = type
+        trace.stats.type = 'variation'
         trace.stats.interval = interval
         trace.stats.network = network
         trace.stats.station = trace1.stats.station


### PR DESCRIPTION
The create missing channel was adding the wrong number of data points at the end by using the length parameter and not the stats.npts. This created issues when cleaning the timeseries. Also re wrote to use delta instead of sampling_rate to make the code clearer and forced the starttime and endtime to be either on the second or minute for their respective intervals.  In the clean timeseries, made sure the start and endtime changes only occurred when the change in time was greater than the delta. Unit tests were written for both of these issues that recreated the problem and then ensured that problem was fixed.