### PR TITLE
Merge streams fix

### DIFF
--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -236,15 +236,16 @@ def merge_streams(*streams):
 =======
 =======
 
+<<<<<<< HEAD
 >>>>>>> fixed rebasing issues
     # print('\n masked trace \n')
     # print(masked_trace)
     # trim masked trace to the same size as other traces and add back to merged stream
+=======
+>>>>>>> Fixed linting and spacing errors and cleaned up code
     if masked_trace:
-        masked_trace.trim(merged[0].stats.starttime,merged[0].stats.endtime)
+        masked_trace.trim(merged[0].stats.starttime, merged[0].stats.endtime)
         merged += masked_trace
-    # print('\n after merging masked trace back in \n')
-    # print(merged)
 
 <<<<<<< HEAD
 

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -195,9 +195,26 @@ def merge_streams(*streams):
         stream with contiguous traces merged, and gaps filled with numpy.nan
     """
     merged = obspy.core.Stream()
+<<<<<<< HEAD
     # add unmasked, split traces to be merged
     for stream in streams:
         merged += mask_stream(stream)
+=======
+    masked_trace = None
+
+    # add unmasked, split traces to be merged
+    for stream in streams:
+        merged += mask_stream(stream)
+
+    # if trace is completely masked separate out to be added back in later
+    for trace in merged:
+        if trace.data.mask.all():
+            if not masked_trace:
+                masked_trace = trace
+            else:
+                masked_trace += trace
+
+>>>>>>> Merge stream issues with empty channels
     # split traces that contain gaps
     merged = merged.split()
     # merge data
@@ -206,6 +223,19 @@ def merge_streams(*streams):
             interpolation_samples=1,
             # 1 = when there is overlap, use data from trace with last endtime
             method=1)
+<<<<<<< HEAD
+=======
+    # print('\n masked trace \n')
+    # print(masked_trace)
+    # trim masked trace to the same size as other traces and add back to merged stream
+    if masked_trace:
+        masked_trace.trim(merged[0].stats.starttime,merged[0].stats.endtime)
+        merged += masked_trace
+    # print('\n after merging masked trace back in \n')
+    # print(merged)
+
+
+>>>>>>> Merge stream issues with empty channels
     # convert back to NaN filled array
     merged = unmask_stream(merged)
     return merged

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -196,10 +196,18 @@ def merge_streams(*streams):
     """
     merged = obspy.core.Stream()
 <<<<<<< HEAD
+<<<<<<< HEAD
     # add unmasked, split traces to be merged
     for stream in streams:
         merged += mask_stream(stream)
 =======
+=======
+
+    # add unmasked, split traces to be merged
+    for stream in streams:
+        merged += mask_stream(stream)
+
+>>>>>>> fixed rebasing issues
     masked_trace = None
 
     # add unmasked, split traces to be merged
@@ -224,7 +232,11 @@ def merge_streams(*streams):
             # 1 = when there is overlap, use data from trace with last endtime
             method=1)
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+
+>>>>>>> fixed rebasing issues
     # print('\n masked trace \n')
     # print(masked_trace)
     # trim masked trace to the same size as other traces and add back to merged stream
@@ -234,8 +246,11 @@ def merge_streams(*streams):
     # print('\n after merging masked trace back in \n')
     # print(merged)
 
+<<<<<<< HEAD
 
 >>>>>>> Merge stream issues with empty channels
+=======
+>>>>>>> fixed rebasing issues
     # convert back to NaN filled array
     merged = unmask_stream(merged)
     return merged

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -195,19 +195,6 @@ def merge_streams(*streams):
         stream with contiguous traces merged, and gaps filled with numpy.nan
     """
     merged = obspy.core.Stream()
-<<<<<<< HEAD
-<<<<<<< HEAD
-    # add unmasked, split traces to be merged
-    for stream in streams:
-        merged += mask_stream(stream)
-=======
-=======
-
-    # add unmasked, split traces to be merged
-    for stream in streams:
-        merged += mask_stream(stream)
-
->>>>>>> fixed rebasing issues
     masked_trace = None
 
     # add unmasked, split traces to be merged
@@ -222,36 +209,22 @@ def merge_streams(*streams):
             else:
                 masked_trace += trace
 
->>>>>>> Merge stream issues with empty channels
     # split traces that contain gaps
     merged = merged.split()
+
+
     # merge data
     merged.merge(
             # 1 = do not interpolate
             interpolation_samples=1,
             # 1 = when there is overlap, use data from trace with last endtime
             method=1)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
 
-<<<<<<< HEAD
->>>>>>> fixed rebasing issues
-    # print('\n masked trace \n')
-    # print(masked_trace)
     # trim masked trace to the same size as other traces and add back to merged stream
-=======
->>>>>>> Fixed linting and spacing errors and cleaned up code
     if masked_trace:
         masked_trace.trim(merged[0].stats.starttime, merged[0].stats.endtime)
         merged += masked_trace
 
-<<<<<<< HEAD
-
->>>>>>> Merge stream issues with empty channels
-=======
->>>>>>> fixed rebasing issues
     # convert back to NaN filled array
     merged = unmask_stream(merged)
     return merged

--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -212,7 +212,6 @@ def merge_streams(*streams):
     # split traces that contain gaps
     merged = merged.split()
 
-
     # merge data
     merged.merge(
             # 1 = do not interpolate
@@ -220,7 +219,8 @@ def merge_streams(*streams):
             # 1 = when there is overlap, use data from trace with last endtime
             method=1)
 
-    # trim masked trace to the same size as other traces and add back to merged stream
+    # trim masked trace to the same size as other traces (not done in merge())
+    # and add back to merged stream
     if masked_trace:
         masked_trace.trim(merged[0].stats.starttime, merged[0].stats.endtime)
         merged += masked_trace

--- a/test/StreamConverter_test.py
+++ b/test/StreamConverter_test.py
@@ -305,7 +305,7 @@ def __create_trace(channel, data, decbase=0):
     """
     stats = obspy.core.Stats()
     stats.starttime = STARTTIME
-    stats.sampling_rate = 0.0166666666667
+    stats.delta = 60
     stats.declination_base = decbase
     stats.channel = channel
     numpy_data = numpy.array(data, dtype=numpy.float64)

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -113,3 +113,41 @@ def test_get_merged_gaps():
     gap = merged[1]
     assert_equals(gap[0], UTCDateTime('2015-01-01T00:00:05Z'))
     assert_equals(gap[1], UTCDateTime('2015-01-01T00:00:07Z'))
+
+def test_merge_streams():
+    """TimeseriesUtility_test.test_merge_streams()
+
+    confirm merge streams treats empty channels correctly
+    """
+    trace1 = __create_trace('H', [1, 1, 1, 1])
+    trace2 = __create_trace('E', [2, numpy.nan, numpy.nan, 2])
+    trace3 = __create_trace('F', [numpy.nan, numpy.nan, numpy.nan, numpy.nan])
+    trace4 = __create_trace('H', [1, 1, 1, 1])
+    trace5 = __create_trace('E', [2, numpy.nan, numpy.nan, 2])
+    trace6 = __create_trace('F', [numpy.nan, numpy.nan, numpy.nan, numpy.nan])
+    npts1 = len(trace1.data)
+    npts2 = len(trace4.data)
+    timeseries1 = Stream(traces=[trace1, trace2, trace3])
+    timeseries2 = Stream(traces=[trace4, trace5, trace6])    
+    for trace in timeseries1:
+        trace.stats.starttime = UTCDateTime('2018-01-01T00:00:00Z')
+        trace.stats.npts = npts1
+    for trace in timeseries2:
+        trace.stats.starttime = UTCDateTime('2018-01-01T00:02:00Z')
+        trace.stats.npts = npts2
+    print(timeseries1)
+    Merged_streams1 = TimeseriesUtility.merge_streams(timeseries1)
+    print(Merged_streams1)
+    assert_equals(len(timeseries1),len(Merged_streams1))
+
+    # Merge multiple streams with overlapping timestamps
+
+
+    timeseries = timeseries1 + timeseries2
+    print(timeseries)    
+    Merged_streams = TimeseriesUtility.merge_streams(timeseries)
+    print('\n Merged Streams before clean \n')
+    print(Merged_streams)
+
+    assert_equals(len(Merged_streams),len(timeseries1))
+    assert_equals(Merged_streams[0])

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -136,12 +136,24 @@ def test_merge_streams():
     for trace in timeseries2:
         trace.stats.starttime = UTCDateTime('2018-01-01T00:02:00Z')
         trace.stats.npts = npts2
-    Merged_streams1 = TimeseriesUtility.merge_streams(timeseries1)
+    merged_streams1 = TimeseriesUtility.merge_streams(timeseries1)
     # Make sure the empty 'F' was not removed from stream
-    assert_equals(len(timeseries1), len(Merged_streams1))
+    assert_equals(1, len(merged_streams1.select(channel = 'F')))
     # Merge multiple streams with overlapping timestamps
     timeseries = timeseries1 + timeseries2
-    Merged_streams = TimeseriesUtility.merge_streams(timeseries)
-    assert_equals(len(Merged_streams), len(timeseries1))
-    assert_equals(len(Merged_streams[0].data), 6)
-    assert_equals(len(Merged_streams[2]), 6)
+    merged_streams = TimeseriesUtility.merge_streams(timeseries)
+    assert_equals(len(merged_streams), len(timeseries1))
+    assert_equals(len(merged_streams[0].data), 6)
+    assert_equals(len(merged_streams[2]), 6)
+
+    trace7 = __create_trace('H', [1,1,1,1])
+    trace8 = __create_trace('E', [numpy.nan, numpy.nan, numpy.nan, numpy.nan])
+    trace9 = __create_trace('F', [numpy.nan, numpy.nan, numpy.nan, numpy.nan])
+    timeseries3 = Stream(traces=[trace7,trace8,trace9])
+    npts3 = len(trace7.data)
+    for trace in timeseries3:
+        trace.stats.starttime = UTCDateTime('2018-01-01T00:00:00Z')
+        trace.stats.npts = npts3
+    merged_streams3 = TimeseriesUtility.merge_streams(timeseries3)
+    assert_equals(len(timeseries3),len(merged_streams3))
+

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -179,7 +179,7 @@ def test_merge_streams():
             True)
 
     trace10 = __create_trace('H', [1, 1, numpy.nan, numpy.nan, 1, 1])
-    trace11 = __create_trace('H', [1, 2, 2, 1])
+    trace11 = __create_trace('H', [2, 2, 2, 2])
     trace10.stats.starttime = UTCDateTime('2018-01-01T00:00:00Z')
     trace11.stats.starttime = UTCDateTime('2018-01-01T00:01:00Z')
     timeseries4 = Stream(traces=[trace10, trace11])
@@ -187,4 +187,4 @@ def test_merge_streams():
     assert_equals(len(merged4[0].data), 6)
     assert_almost_equal(
         merged4.select(channel='H')[0].data,
-        [1, 1, 2, 2, 1, 1])
+        [1, 2, 2, 2, 1, 1])

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -114,6 +114,7 @@ def test_get_merged_gaps():
     assert_equals(gap[0], UTCDateTime('2015-01-01T00:00:05Z'))
     assert_equals(gap[1], UTCDateTime('2015-01-01T00:00:07Z'))
 
+
 def test_merge_streams():
     """TimeseriesUtility_test.test_merge_streams()
 
@@ -128,26 +129,19 @@ def test_merge_streams():
     npts1 = len(trace1.data)
     npts2 = len(trace4.data)
     timeseries1 = Stream(traces=[trace1, trace2, trace3])
-    timeseries2 = Stream(traces=[trace4, trace5, trace6])    
+    timeseries2 = Stream(traces=[trace4, trace5, trace6])
     for trace in timeseries1:
         trace.stats.starttime = UTCDateTime('2018-01-01T00:00:00Z')
         trace.stats.npts = npts1
     for trace in timeseries2:
         trace.stats.starttime = UTCDateTime('2018-01-01T00:02:00Z')
         trace.stats.npts = npts2
-    print(timeseries1)
     Merged_streams1 = TimeseriesUtility.merge_streams(timeseries1)
-    print(Merged_streams1)
-    assert_equals(len(timeseries1),len(Merged_streams1))
-
+    # Make sure the empty 'F' was not removed from stream
+    assert_equals(len(timeseries1), len(Merged_streams1))
     # Merge multiple streams with overlapping timestamps
-
-
     timeseries = timeseries1 + timeseries2
-    print(timeseries)    
     Merged_streams = TimeseriesUtility.merge_streams(timeseries)
-    print('\n Merged Streams before clean \n')
-    print(Merged_streams)
-
-    assert_equals(len(Merged_streams),len(timeseries1))
-    assert_equals(Merged_streams[0])
+    assert_equals(len(Merged_streams), len(timeseries1))
+    assert_equals(len(Merged_streams[0].data), 6)
+    assert_equals(len(Merged_streams[2]), 6)

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -177,3 +177,14 @@ def test_merge_streams():
     assert_equals(
             numpy.isnan(timeseries3.select(channel='F')[0].data).all(),
             True)
+
+    trace10 = __create_trace('H', [1, 1, numpy.nan, numpy.nan, 1, 1])
+    trace11 = __create_trace('H', [1, 2, 2, 1])
+    trace10.stats.starttime = UTCDateTime('2018-01-01T00:00:00Z')
+    trace11.stats.starttime = UTCDateTime('2018-01-01T00:01:00Z')
+    timeseries4 = Stream(traces=[trace10, trace11])
+    merged4 = TimeseriesUtility.merge_streams(timeseries4)
+    assert_equals(len(merged4[0].data), 6)
+    assert_almost_equal(
+        merged4.select(channel='H')[0].data,
+        [1, 1, 2, 2, 1, 1])


### PR DESCRIPTION
Do I need to rebase so that the travis.yml and EdgeFactory fixes do not show up? Either way this fixes an issue where the merge streams completely drops a channel if it is empty. This just saves that channel, trims it to the new start and end times, and then adds the channel back to the stream before returning the full stream. Created a unit test for this as well. One issue is it seams the endtimes after the merge streams seem to be at 59 seconds instead of on the minute which is expected for minute data.