### PR TITLE
Trap errors when elevation is not correctly set

### DIFF
--- a/geomagio/imfjson/IMFJSONWriter.py
+++ b/geomagio/imfjson/IMFJSONWriter.py
@@ -122,8 +122,11 @@ class IMFJSONWriter(object):
             coords[0] = float(stats.geodetic_longitude)
         if 'geodetic_latitude' in stats:
             coords[1] = float(stats.geodetic_latitude)
-        if 'elevation' in stats:
-            coords[2] = float(stats.elevation)
+        try:
+            if 'elevation' in stats:
+                coords[2] = float(stats.elevation)
+        except (KeyError, ValueError, TypeError):
+            pass
         imo['coordinates'] = coords
         intermag['imo'] = imo
         intermag['reported_orientation'] = ''.join(channels)


### PR DESCRIPTION
Fixes #219 

Using proposed solution for now, eventually elevation should either not be set or set to `None` when empty.