### PR TITLE
Fix AlgorithmException string in SqDistAlgorithm

### DIFF
--- a/geomagio/WebServiceUsage.py
+++ b/geomagio/WebServiceUsage.py
@@ -33,7 +33,7 @@ class WebServiceUsage(object):
             ids += "<code>" + obs_id + "</code>"
             if idx != len(observatories) - 1:
                 ids += ", "
-            if idx % 9 == 0 and idx is not 0:
+            if idx % 9 == 0 and idx != 0:
                 ids += "<br/>"
         usage_body = """
             <!doctype html>

--- a/geomagio/algorithm/SqDistAlgorithm.py
+++ b/geomagio/algorithm/SqDistAlgorithm.py
@@ -221,7 +221,7 @@ class SqDistAlgorithm(Algorithm):
                 # state not correct
                 raise AlgorithmException(
                         'Inconsistent SQDist algorithm state' +
-                        ' state(%s, %s, %s, %s) <> process(%s, %s, %s, %s)' %
+                        ' process(%s, %s, %s, %s) <> state(%s, %s, %s, %s)' %
                                 (trace.stats.station,
                                 trace.stats.channel,
                                 trace.stats.delta,


### PR DESCRIPTION
As per discussion in geomag-algorithms issue #236, swap the "state" and "process"
strings in the AlgorithmException string. Fixes #236.