### PR TITLE
Version to 0.8.1 in package.json and setup.py

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geomag-algorithms",
-  "version": "0.7.1",
+  "version": "0.8.1",
   "homepage": "http://geomag.usgs.gov/",
   "repository": "https://github.com/usgs/geomag-algorithms.git",
   "description": "Geomagnetism algorithms.",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='geomag-algorithms',
-    version='0.7.1',
+    version='0.8.1',
     description='USGS Geomag IO Library',
     url='https://github.com/usgs/geomag-algorithms',
     packages=[


### PR DESCRIPTION
We hadn't actually updated version info since 0.7.1. This will be the only
change before cutting a new release tag. There will be no need to re-deploy
to the Dev edge, which received v0.8.0 already.