### PR TITLE
Add can_produce_data() method to AdjustedAlgorithm

### DIFF
--- a/geomagio/algorithm/AdjustedAlgorithm.py
+++ b/geomagio/algorithm/AdjustedAlgorithm.py
@@ -154,6 +154,46 @@ class AdjustedAlgorithm(Algorithm):
 
         return out
 
+    def can_produce_data(self, starttime, endtime, stream):
+        """Can Product data
+        Parameters
+        ----------
+        starttime: UTCDateTime
+            start time of requested output
+        end : UTCDateTime
+            end time of requested output
+        stream: obspy.core.Stream
+            The input stream we want to make certain has data for the algorithm
+        """
+
+        # collect channels in stream
+        channels = []
+        for trace in stream:
+            channels += trace.stats['channel']
+
+        # if F is available, can produce at least adjusted F
+        if ('F' in channels and
+            super(AdjustedAlgorithm, self).can_produce_data(
+                starttime,
+                endtime,
+                stream.select(channel='F'))):
+            return True
+
+        # if HEZ are available, can produce at least adjusted XYZ
+        if ('H' in channels and
+            'E' in channels and
+            'Z' in channels and
+            np.all(
+                [super(AdjustedAlgorithm, self).can_produce_data(
+                     starttime,
+                     endtime,
+                     stream.select(channel=chan))
+                 for chan in ('H', 'E', 'Z')])):
+            return True
+
+        # return false if cannot produce adjustded F or XYZ
+        return False
+
     @classmethod
     def add_arguments(cls, parser):
         """Add command line arguments to argparse parser.


### PR DESCRIPTION
AdjustedAlgorithm.process() essentially adjusts two values:

 - 3D vector field HEZ_raw -> XYZ_adj
 - 1D scalar field F_raw -> F_adj

Neither should depend on the other, but this was implicitly the case
as originally implemented. When F was missing, this prevented XYZ
from being calculated, at least when called in 'update' mode by the
Controller. Likewise, if HEZ were missing, this prevented adjusted F
from being calculated.