### PR TITLE
Make filter algorithm process any channels

### DIFF
--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -270,8 +270,6 @@ def has_all_channels(stream, channels, starttime, endtime):
     """
     input_gaps = get_merged_gaps(
             get_stream_gaps(stream=stream, channels=channels))
-    print(starttime, endtime)
-    print(input_gaps)
     for input_gap in input_gaps:
         # Check for gaps that include the entire range
         if (starttime >= input_gap[0] and

--- a/geomagio/algorithm/Algorithm.py
+++ b/geomagio/algorithm/Algorithm.py
@@ -88,7 +88,9 @@ class Algorithm(object):
         return (start, end)
 
     def can_produce_data(self, starttime, endtime, stream):
-        """Can Product data
+        """Can Produce data
+
+        By default require all channels to have data at the same time.
 
         Parameters
         ----------
@@ -99,17 +101,11 @@ class Algorithm(object):
         stream: obspy.core.Stream
             The input stream we want to make certain has data for the algorithm
         """
-        input_gaps = TimeseriesUtility.get_merged_gaps(
-                TimeseriesUtility.get_stream_gaps(
-                    stream=stream,
-                    channels=self.get_required_channels()))
-        for input_gap in input_gaps:
-            # Check for gaps that include the entire range
-            if (starttime >= input_gap[0] and
-                    starttime <= input_gap[1] and
-                    endtime < input_gap[2]):
-                return False
-        return True
+        return TimeseriesUtility.has_all_channels(
+                stream,
+                self.get_required_channels(),
+                starttime,
+                endtime)
 
     def get_next_starttime(self):
         """Check whether algorithm has a stateful start time.

--- a/test/TimeseriesUtility_test.py
+++ b/test/TimeseriesUtility_test.py
@@ -90,7 +90,6 @@ def test_get_stream_gaps_channels():
 
     test that gaps are only checked in specified channels.
     """
-    stream = Stream
     stream = Stream([
         __create_trace('H', [numpy.nan, 1, 1, numpy.nan, numpy.nan]),
         __create_trace('Z', [0, 0, 0, 1, 1, 1])
@@ -161,6 +160,58 @@ def test_get_merged_gaps():
     gap = merged[1]
     assert_equal(gap[0], UTCDateTime('2015-01-01T00:00:05Z'))
     assert_equal(gap[1], UTCDateTime('2015-01-01T00:00:07Z'))
+
+
+def test_has_all_channels():
+    """TimeseriesUtility_test.test_has_all_channels():
+    """
+    nan = numpy.nan
+    stream = Stream([
+        __create_trace('H', [nan, 1, 1, nan, nan]),
+        __create_trace('Z', [0, 0, 0, 1, 1]),
+        __create_trace('E', [nan, nan, nan, nan, nan])
+    ])
+    for trace in stream:
+        # set time of first sample
+        trace.stats.starttime = UTCDateTime('2015-01-01T00:00:00Z')
+        # set sample rate to 1 second
+        trace.stats.delta = 1
+        trace.stats.npts = len(trace.data)
+    # check for channels
+    starttime = stream[0].stats.starttime
+    endtime = stream[0].stats.endtime
+    assert_equal(TimeseriesUtility.has_all_channels(
+            stream, ['H', 'Z'], starttime, endtime), True)
+    assert_equal(TimeseriesUtility.has_all_channels(
+            stream, ['H', 'Z', 'E'], starttime, endtime), False)
+    assert_equal(TimeseriesUtility.has_all_channels(
+            stream, ['E'], starttime, endtime), False)
+
+
+def test_has_any_channels():
+    """TimeseriesUtility_test.test_has_any_channels():
+    """
+    nan = numpy.nan
+    stream = Stream([
+        __create_trace('H', [nan, 1, 1, nan, nan]),
+        __create_trace('Z', [0, 0, 0, 1, 1, 1]),
+        __create_trace('E', [nan, nan, nan, nan, nan])
+    ])
+    for trace in stream:
+        # set time of first sample
+        trace.stats.starttime = UTCDateTime('2015-01-01T00:00:00Z')
+        # set sample rate to 1 second
+        trace.stats.delta = 1
+        trace.stats.npts = len(trace.data)
+    # check for channels
+    starttime = stream[0].stats.starttime
+    endtime = stream[0].stats.endtime
+    assert_equal(TimeseriesUtility.has_any_channels(
+            stream, ['H', 'Z'], starttime, endtime), True)
+    assert_equal(TimeseriesUtility.has_any_channels(
+            stream, ['H', 'Z', 'E'], starttime, endtime), True)
+    assert_equal(TimeseriesUtility.has_any_channels(
+            stream, ['E'], starttime, endtime), False)
 
 
 def test_merge_streams():


### PR DESCRIPTION
Fixes #274 (I think).

@erigler-usgs take a look, this makes filter run if any of its input channels have data.  It does not check whether there are enough samples to produce valid data, or non-nan output.  I think this is along the lines of what you described.

It may be possible to apply this to other algorithms that have variable input requirements, but that is left for later.