### PR TITLE
Handle empty buffer returned from Edge

### DIFF
--- a/geomagio/edge/EdgeFactory.py
+++ b/geomagio/edge/EdgeFactory.py
@@ -484,9 +484,14 @@ class EdgeFactory(TimeseriesFactory):
         location = self._get_edge_location(observatory, channel, type, interval)
         network = self._get_edge_network(observatory, channel, type, interval)
         edge_channel = self._get_edge_channel(observatory, channel, type, interval)
-        data = self.client.get_waveforms(
-            network, station, location, edge_channel, starttime, endtime
-        )
+        try:
+            data = self.client.get_waveforms(
+                network, station, location, edge_channel, starttime, endtime
+            )
+        except TypeError:
+            # get_waveforms() fails if no data is returned from Edge
+            data = obspy.core.Stream()
+
         # make sure data is 32bit int
         for trace in data:
             trace.data = trace.data.astype("i4")


### PR DESCRIPTION
ObsPy's waveserver.py (and associated methods) do not handle an empty
buffer returned from Edge's earthworm server. In short, they generate
a None value instead of an empty byte string as one might expect (and
they clearly did expect, since they attempted `len(dat)` where dat
was expected to be a byte string, but was a None object if/when Edge
had no data. This fix employs a try/except clause to generate an
empty ~string~ stream if the waveserver client fails with a TypeError, as is
the case when Edge returns an empty buffer.