### PR TITLE
Add SJT preliminary metadata to metadata.py

### DIFF
--- a/geomagio/Metadata.py
+++ b/geomagio/Metadata.py
@@ -106,4 +106,36 @@ _INSTRUMENT_METADATA = [
             },
         },
     },
+    {
+        "network": "NT",
+        "station": "SJT",
+        "start_time": None,
+        "end_time": None,
+        "instrument": {
+            "type": "FGE",
+            "channels": {
+                # each channel maps to a list of components to calculate nT
+                # TODO: calculate these lists based on "FGE" type
+                "U": [{"channel": "U_Volt", "offset": 0, "scale": 320.0}],
+                "V": [{"channel": "V_Volt", "offset": 0, "scale": 320.0}],
+                "W": [{"channel": "W_Volt", "offset": 0, "scale": 320.0}],
+            },
+            ## this info should get updated when available
+            # "electronics": {
+            #     "serial": "E0542",
+            #     # these scale values are used to convert voltage
+            #     "x-scale": 313.2,  # V/nT
+            #     "y-scale": 312.3,  # V/nT
+            #     "z-scale": 312.0,  # V/nT
+            #     "temperature-scale": 0.01,  # V/K
+            # },
+            # "sensor": {
+            #     "serial": "S0419",
+            #     # these constants combine with instrument setting for offset
+            #     "x-constant": 36958,  # nT/mA
+            #     "y-constant": 36849,  # nT/mA
+            #     "z-constant": 36811,  # nT/mA
+            # },
+        },
+    },
 ]


### PR DESCRIPTION
The actual calibration coefficints are filed in the GHSC, but due to
COVID-19 telework policies at the moment, it is not possible to go
and retrieve these. We've used nominal scaling values for the SJT
FGE fluxgate magnetometer here, providing only bare minimal info.
Once business returns to normal, this file should be updated for
SJT.