### PR TITLE
Fix TimeseriesUtility.pad_and_trim_trace

### DIFF
--- a/geomagio/TimeseriesUtility.py
+++ b/geomagio/TimeseriesUtility.py
@@ -514,7 +514,7 @@ def pad_and_trim_trace(trace, starttime, endtime):
             trace.stats.starttime = trace_starttime
     elif trace_starttime > starttime:
         # pad to starttime
-        cnt = int((trace_starttime - starttime) / trace_delta)
+        cnt = round((trace_starttime - starttime) / trace_delta)
         if cnt > 0:
             trace.data = numpy.concatenate(
                 [numpy.full(cnt, numpy.nan, dtype=numpy.float64), trace.data]
@@ -528,7 +528,7 @@ def pad_and_trim_trace(trace, starttime, endtime):
         trace.stats.npts = len(trace.data)
     elif trace_endtime < endtime:
         # pad to endtime
-        cnt = int((endtime - trace_endtime) / trace.stats.delta)
+        cnt = round((endtime - trace_endtime) / trace.stats.delta)
         if cnt > 0:
             trace.data = numpy.concatenate(
                 [trace.data, numpy.full(cnt, numpy.nan, dtype=numpy.float64)]


### PR DESCRIPTION
I ran into a floating point precision issue when padding a trace out
to the requested starttime when the data block returned by the Edge
miniseed factory (but this is not an Edge issue, per se) was less
than what was requested.

My solution was to use `round()` instead of `int()` when converting
a time differential to a discrete number of samples. I'm confident
this is a robust fix for padding. I'm not sure if it also the proper
approach to the trimming, which seems to be a bit more sophisticated
in that is uses the `ceil()` method. In any case, I request some
feedback before merging this deceptively simple PR.